### PR TITLE
Add 'Not All Infinities Are Equal' post, CiteAs, math fix

### DIFF
--- a/src/components/CiteAs.astro
+++ b/src/components/CiteAs.astro
@@ -1,0 +1,204 @@
+---
+import { SITE_AUTHOR, SITE_TITLE } from '../consts';
+
+interface PaperRef {
+  title: string;
+  authors?: string;
+  year: number | string;
+  venue?: string;
+  arxiv?: string; // e.g. "2605.03262"
+  url?: string;
+}
+
+interface Props {
+  slug: string;
+  title: string;
+  pubDate: Date | string;
+  paper?: PaperRef;
+}
+
+const props = Astro.props;
+const { slug, title, paper } = props;
+const pubDate = props.pubDate instanceof Date ? props.pubDate : new Date(props.pubDate);
+
+const site = Astro.site?.toString() ?? 'https://tahabouhsine.com/';
+const blogUrl = new URL(`/blog/${slug}/`, site).toString();
+const year = pubDate.getUTCFullYear();
+const monthAbbrev = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'][pubDate.getUTCMonth()];
+
+const blogBibKey = `bouhsine${year}${slug.replace(/-/g, '')}`;
+const blogBib = `@misc{${blogBibKey},
+  author       = {Bouhsine, Taha},
+  title        = {${title}},
+  year         = {${year}},
+  month        = {${monthAbbrev}},
+  howpublished = {\\url{${blogUrl}}},
+  note         = {Blog post, ${SITE_TITLE}}
+}`;
+
+const buildPaperBib = (p: PaperRef): { key: string; entry: string } => {
+  const surname = (p.authors ?? SITE_AUTHOR).split(',')[0].split(' ').slice(-1)[0].toLowerCase();
+  const slugBit = p.arxiv ? p.arxiv.replace('.', '') : (p.title.split(/\s+/).slice(0, 2).join('').toLowerCase().replace(/[^a-z0-9]/g, ''));
+  const key = `${surname}${p.year}${slugBit}`;
+  if (p.arxiv) {
+    return {
+      key,
+      entry: `@article{${key},
+  author        = {${p.authors ?? 'Bouhsine, Taha'}},
+  title         = {${p.title}},
+  year          = {${p.year}},
+  eprint        = {${p.arxiv}},
+  archivePrefix = {arXiv}${p.venue ? `,\n  journal       = {${p.venue}}` : ''}
+}`,
+    };
+  }
+  return {
+    key,
+    entry: `@unpublished{${key},
+  author = {${p.authors ?? 'Bouhsine, Taha'}},
+  title  = {${p.title}},
+  year   = {${p.year}}${p.venue ? `,\n  note   = {${p.venue}}` : ''}
+}`,
+  };
+};
+
+const paperBib = paper ? buildPaperBib(paper) : null;
+const paperUrl = paper ? (paper.url ?? (paper.arxiv ? `https://arxiv.org/abs/${paper.arxiv}` : undefined)) : undefined;
+
+const dateFmt = new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+---
+<section class="cite-as" aria-labelledby={`cite-${slug}`}>
+  <h2 id={`cite-${slug}`}>Cite as</h2>
+
+  <p class="cite-line">
+    Bouhsine, T. (<time datetime={pubDate.toISOString()}>{year}, {dateFmt.format(pubDate).replace(/^.*?, /, '')}</time>).
+    <em>{title}</em>. {SITE_TITLE}.
+    <a href={blogUrl}>{blogUrl}</a>
+  </p>
+
+  <details class="cite-bib">
+    <summary>BibTeX</summary>
+    <pre><code class="bibtex">{blogBib}</code></pre>
+    <button type="button" class="cite-copy" data-copy={blogBib} aria-label="Copy BibTeX">copy</button>
+  </details>
+
+  {paper && paperBib && (
+    <>
+      <h3>For the underlying paper</h3>
+      <p class="cite-line">
+        {paper.authors ?? 'Bouhsine, T.'} ({paper.year}).
+        <em> {paper.title}</em>.
+        {paper.arxiv && <> arXiv:<a href={`https://arxiv.org/abs/${paper.arxiv}`}>{paper.arxiv}</a>.</>}
+        {paper.venue && !paper.arxiv && <> {paper.venue}.</>}
+        {paperUrl && !paper.arxiv && <> <a href={paperUrl}>{paperUrl}</a></>}
+      </p>
+      <details class="cite-bib">
+        <summary>BibTeX</summary>
+        <pre><code class="bibtex">{paperBib.entry}</code></pre>
+        <button type="button" class="cite-copy" data-copy={paperBib.entry} aria-label="Copy BibTeX">copy</button>
+      </details>
+    </>
+  )}
+</section>
+
+<style>
+  .cite-as {
+    margin: 3.5rem 0 0;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+  }
+  .cite-as h2 {
+    font-family: var(--mono);
+    font-size: 0.82rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--fg-faint);
+    font-weight: 500;
+    margin: 0 0 0.75rem;
+  }
+  .cite-as h3 {
+    font-family: var(--mono);
+    font-size: 0.78rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--fg-faint);
+    font-weight: 500;
+    margin: 1.5rem 0 0.6rem;
+  }
+  .cite-line {
+    font-family: var(--serif);
+    font-size: 0.98rem;
+    line-height: 1.55;
+    color: var(--fg-muted);
+    margin: 0 0 0.5rem;
+  }
+  .cite-line em { color: var(--fg); }
+  .cite-bib {
+    margin: 0.4rem 0 0;
+    position: relative;
+  }
+  .cite-bib summary {
+    cursor: pointer;
+    font-family: var(--mono);
+    font-size: 0.78rem;
+    color: var(--fg-muted);
+    padding: 0.25rem 0;
+    user-select: none;
+  }
+  .cite-bib summary:hover { color: var(--accent); }
+  .cite-bib pre {
+    margin: 0.4rem 0 0;
+    padding: 0.85rem 1rem;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow-x: auto;
+    font-size: 0.82rem;
+    line-height: 1.55;
+  }
+  .cite-bib pre code { background: transparent; border: 0; padding: 0; }
+  .cite-copy {
+    position: absolute;
+    top: 2.1rem;
+    right: 0.55rem;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    color: var(--fg-muted);
+    font-family: var(--mono);
+    font-size: 0.72rem;
+    padding: 0.25rem 0.55rem;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: color var(--transition-fast), border-color var(--transition-fast);
+  }
+  .cite-copy:hover { color: var(--accent); border-color: var(--accent); }
+  .cite-copy.copied { color: var(--accent); border-color: var(--accent); }
+</style>
+
+<script is:inline>
+  (() => {
+    const enhance = () => {
+      document.querySelectorAll('.cite-copy').forEach((btn) => {
+        if (btn.dataset.bound) return;
+        btn.dataset.bound = '1';
+        btn.addEventListener('click', async () => {
+          try {
+            await navigator.clipboard.writeText(btn.dataset.copy || '');
+            const original = btn.textContent;
+            btn.textContent = 'copied';
+            btn.classList.add('copied');
+            setTimeout(() => {
+              btn.textContent = original;
+              btn.classList.remove('copied');
+            }, 1500);
+          } catch {
+            btn.textContent = 'error';
+          }
+        });
+      });
+    };
+    enhance();
+    document.addEventListener('astro:page-load', enhance);
+    document.addEventListener('astro:after-swap', enhance);
+  })();
+</script>

--- a/src/components/viz/AsymmetryBars.astro
+++ b/src/components/viz/AsymmetryBars.astro
@@ -1,0 +1,335 @@
+---
+interface Props {
+  caption?: string;
+  height?: number;
+}
+const { caption, height = 320 } = Astro.props;
+const id = `ab-${Math.random().toString(36).slice(2, 9)}`;
+---
+<figure class="viz">
+  <div class="viz-controls ab-controls" data-ab={id}>
+    <div class="ab-presets">
+      <span class="faint" style="margin-right:0.4rem">preset:</span>
+      <button type="button" data-preset="match" class="active">match (q = p)</button>
+      <button type="button" data-preset="miss">miss truth on C</button>
+      <button type="button" data-preset="add">add falsehood on D</button>
+    </div>
+    <span class="faint">drag the top of any q bar to adjust</span>
+  </div>
+  <canvas id={`${id}-c`} height={height} aria-label="Asymmetry of cross-entropy under truth distribution p and model distribution q"></canvas>
+  <div class="ab-readouts" id={`${id}-readouts`}>
+    <div class="ab-cell"><span class="readout-label">H(p, q)</span><span class="readout-val" data-key="pq">—</span><span class="readout-tag" data-key="pq-tag">—</span></div>
+    <div class="ab-cell"><span class="readout-label">H(q, p)</span><span class="readout-val" data-key="qp">—</span><span class="readout-tag" data-key="qp-tag">—</span></div>
+    <div class="ab-cell"><span class="readout-label">violating mass S(p, q)</span><span class="readout-val" data-key="s">—</span></div>
+  </div>
+  {caption && <figcaption>{caption}</figcaption>}
+</figure>
+
+<style>
+  .ab-controls { flex-direction: column; align-items: stretch; }
+  .ab-presets { display: flex; flex-wrap: wrap; gap: 0.35rem; align-items: center; }
+  .ab-presets button {
+    font-family: var(--mono);
+    font-size: 0.78rem;
+    padding: 0.3rem 0.7rem;
+    background: var(--bg);
+    color: var(--fg-muted);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: all var(--transition-fast);
+  }
+  .ab-presets button:hover { color: var(--accent); border-color: var(--accent); }
+  .ab-presets button.active { color: var(--bg); background: var(--accent); border-color: var(--accent); }
+  .ab-readouts {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.5rem;
+    margin-top: 0.6rem;
+    font-family: var(--mono);
+    font-size: 0.86rem;
+  }
+  .ab-cell {
+    background: var(--bg-sunken);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.55rem 0.7rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+  .ab-cell .readout-label { color: var(--fg-muted); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.05em; }
+  .ab-cell .readout-val { color: var(--fg); font-variant-numeric: tabular-nums; font-size: 1.05rem; }
+  .ab-cell .readout-tag { color: var(--accent); font-size: 0.72rem; }
+  @media (max-width: 640px) {
+    .ab-readouts { grid-template-columns: 1fr; }
+  }
+</style>
+
+<script is:inline define:vars={{ id }}>
+(() => {
+  const readColors = () => {
+    const s = getComputedStyle(document.documentElement);
+    const v = (n) => s.getPropertyValue(n).trim();
+    return {
+      accent: v('--accent') || '#b3661b',
+      muted: v('--fg-muted') || '#5a5f66',
+      faint: v('--fg-faint') || '#8d8d8d',
+      border: v('--border') || '#e4e1d6',
+      fg: v('--fg') || '#1a1a1a',
+    };
+  };
+  let colors = readColors();
+
+  const labels = ['A', 'B', 'C', 'D'];
+
+  const setup = () => {
+    const c = document.getElementById(id + '-c');
+    if (!c || c.dataset.ready) return;
+    c.dataset.ready = '1';
+    const ctx = c.getContext('2d');
+    const wrap = document.querySelector(`[data-ab="${id}"]`);
+    const presets = wrap.querySelectorAll('.ab-presets button');
+    const readouts = document.getElementById(id + '-readouts');
+    const rv = {};
+    readouts.querySelectorAll('[data-key]').forEach((el) => { rv[el.dataset.key] = el; });
+
+    // Fixed truth: A=0.5, B=0.3, C=0.2, D=0
+    const p = [0.5, 0.3, 0.2, 0];
+    // Initial q = p
+    let q = [...p];
+    const state = { dpr: 1, w: 0, h: 0 };
+
+    const fit = () => {
+      const rect = c.getBoundingClientRect();
+      const dpr = Math.max(1, Math.min(window.devicePixelRatio || 1, 2));
+      state.dpr = dpr;
+      state.w = rect.width;
+      state.h = rect.height;
+      c.width = Math.round(rect.width * dpr);
+      c.height = Math.round(rect.height * dpr);
+    };
+
+    const themeObs = new MutationObserver(() => { colors = readColors(); requestRedraw(); });
+    themeObs.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+
+    let rafScheduled = false;
+    let visible = false;
+    const requestRedraw = () => {
+      if (rafScheduled || !visible) return;
+      rafScheduled = true;
+      requestAnimationFrame(() => { rafScheduled = false; draw(); });
+    };
+
+    // Renormalize q so sum = 1; if user dragged index i to value v, scale others
+    const setQ = (i, v) => {
+      v = Math.max(0, Math.min(1, v));
+      const others = q.reduce((a, x, k) => a + (k === i ? 0 : x), 0);
+      const want = 1 - v;
+      if (others > 1e-9) {
+        const scale = want / others;
+        for (let k = 0; k < q.length; k++) if (k !== i) q[k] *= scale;
+      } else {
+        // distribute uniformly
+        for (let k = 0; k < q.length; k++) if (k !== i) q[k] = want / (q.length - 1);
+      }
+      q[i] = v;
+    };
+
+    // Layout helpers — bars share x axis layout
+    const layoutBars = () => {
+      const W = state.w, H = state.h;
+      const padL = 30, padR = 20, padT = 16, padB = 38;
+      const plotW = W - padL - padR;
+      const plotH = H - padT - padB;
+      const n = labels.length;
+      const groupW = plotW / n;
+      const innerPad = groupW * 0.18;
+      const halfW = (groupW - 2 * innerPad) / 2; // p on left, q on right of each group
+      const xCenter = (i) => padL + groupW * i + groupW / 2;
+      const pX = (i) => xCenter(i) - halfW - 2;
+      const qX = (i) => xCenter(i) + 2;
+      const barW = halfW - 1;
+      const baseY = padT + plotH;
+      return { padL, padR, padT, padB, plotW, plotH, xCenter, pX, qX, barW, baseY, plotMaxH: plotH };
+    };
+
+    const yForP = (val, L) => L.baseY - val * L.plotMaxH * 0.95;
+
+    const draw = () => {
+      const W = state.w, H = state.h;
+      if (W === 0) return;
+      ctx.setTransform(state.dpr, 0, 0, state.dpr, 0, 0);
+      ctx.clearRect(0, 0, W, H);
+      const { accent, muted, faint, border, fg } = colors;
+      const L = layoutBars();
+
+      // Frame line at top of bars (0..1)
+      ctx.strokeStyle = border;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(L.padL, L.baseY); ctx.lineTo(L.padL + L.plotW, L.baseY);
+      ctx.stroke();
+
+      // 0.5 reference line
+      ctx.strokeStyle = border;
+      ctx.setLineDash([3, 4]);
+      ctx.beginPath();
+      ctx.moveTo(L.padL, yForP(0.5, L)); ctx.lineTo(L.padL + L.plotW, yForP(0.5, L));
+      ctx.stroke();
+      ctx.setLineDash([]);
+      ctx.fillStyle = faint;
+      ctx.font = '10px ui-monospace, monospace';
+      ctx.textAlign = 'right';
+      ctx.textBaseline = 'middle';
+      ctx.fillText('0.5', L.padL - 4, yForP(0.5, L));
+      ctx.fillText('0', L.padL - 4, L.baseY);
+      ctx.fillText('1', L.padL - 4, yForP(1, L));
+
+      // Bars
+      for (let i = 0; i < labels.length; i++) {
+        // p (outlined, muted fill)
+        const pH = p[i] * L.plotMaxH * 0.95;
+        ctx.fillStyle = muted + '33';
+        ctx.strokeStyle = muted;
+        ctx.lineWidth = 1;
+        ctx.fillRect(L.pX(i), L.baseY - pH, L.barW, pH);
+        ctx.strokeRect(L.pX(i), L.baseY - pH, L.barW, pH);
+
+        // q (accent fill)
+        const qH = q[i] * L.plotMaxH * 0.95;
+        ctx.fillStyle = accent;
+        ctx.strokeStyle = accent;
+        ctx.fillRect(L.qX(i), L.baseY - qH, L.barW, qH);
+        ctx.strokeRect(L.qX(i), L.baseY - qH, L.barW, qH);
+
+        // Top handle for q
+        ctx.fillStyle = colors.bg || '#fff';
+        ctx.strokeStyle = accent;
+        ctx.lineWidth = 1.5;
+        ctx.beginPath();
+        ctx.arc(L.qX(i) + L.barW / 2, L.baseY - qH, 4, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.stroke();
+
+        // Label
+        ctx.fillStyle = faint;
+        ctx.font = '11px ui-monospace, monospace';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'top';
+        ctx.fillText(labels[i], L.xCenter(i), L.baseY + 4);
+
+        // Note for D
+        if (i === 3 && p[i] === 0) {
+          ctx.fillStyle = faint;
+          ctx.font = '9px ui-monospace, monospace';
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'top';
+          ctx.fillText('(p = 0)', L.xCenter(i), L.baseY + 18);
+        }
+      }
+
+      // Legend
+      ctx.font = '10px ui-monospace, monospace';
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'middle';
+      ctx.fillStyle = muted;
+      ctx.fillRect(L.padL, L.padT, 10, 8);
+      ctx.strokeStyle = muted; ctx.lineWidth = 1; ctx.strokeRect(L.padL, L.padT, 10, 8);
+      ctx.fillStyle = faint;
+      ctx.fillText('p (truth)', L.padL + 14, L.padT + 4);
+      ctx.fillStyle = accent;
+      ctx.fillRect(L.padL + 70, L.padT, 10, 8);
+      ctx.fillStyle = faint;
+      ctx.fillText('q (model)', L.padL + 84, L.padT + 4);
+
+      // Compute cross-entropies
+      const ce = (a, b) => {
+        let total = 0;
+        for (let i = 0; i < a.length; i++) {
+          if (a[i] > 0) {
+            if (b[i] <= 0) return Infinity;
+            total -= a[i] * Math.log(b[i]);
+          }
+        }
+        return total;
+      };
+      const Hpq = ce(p, q);
+      const Hqp = ce(q, p);
+      const violating = p.reduce((s, x, i) => s + (x > 0 && q[i] <= 0 ? x : 0), 0);
+      const inverseViol = q.reduce((s, x, i) => s + (x > 0 && p[i] <= 0 ? x : 0), 0);
+
+      const fmt = (x) => Number.isFinite(x) ? x.toFixed(3) + ' nats' : '∞';
+      rv.pq.textContent = fmt(Hpq);
+      rv.qp.textContent = fmt(Hqp);
+      rv.s.textContent = violating.toFixed(3);
+
+      if (!Number.isFinite(Hpq)) rv['pq-tag'].textContent = '↑ model missing truth at some coord';
+      else rv['pq-tag'].textContent = 'finite — model covers all of p';
+      if (!Number.isFinite(Hqp)) rv['qp-tag'].textContent = '↑ model claims mass where p has none';
+      else rv['qp-tag'].textContent = 'finite — q matches p’s support';
+    };
+
+    // Drag handling on q bar tops
+    let dragIdx = -1;
+    const hitTest = (e) => {
+      const rect = c.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const L = layoutBars();
+      for (let i = 0; i < labels.length; i++) {
+        if (x >= L.qX(i) - 4 && x <= L.qX(i) + L.barW + 4) return i;
+      }
+      return -1;
+    };
+    const setFromPointer = (e) => {
+      if (dragIdx < 0) return;
+      const rect = c.getBoundingClientRect();
+      const y = e.clientY - rect.top;
+      const L = layoutBars();
+      const v = Math.max(0, Math.min(1, (L.baseY - y) / (L.plotMaxH * 0.95)));
+      setQ(dragIdx, v);
+      // mark active preset off
+      presets.forEach((b) => b.classList.remove('active'));
+      requestRedraw();
+    };
+    c.addEventListener('pointerdown', (e) => {
+      const i = hitTest(e);
+      if (i < 0) return;
+      dragIdx = i;
+      c.setPointerCapture?.(e.pointerId);
+      setFromPointer(e);
+    });
+    c.addEventListener('pointermove', (e) => { if (dragIdx >= 0) setFromPointer(e); });
+    c.addEventListener('pointerup', (e) => {
+      dragIdx = -1;
+      try { c.releasePointerCapture?.(e.pointerId); } catch {}
+    });
+
+    const setPreset = (name) => {
+      if (name === 'match') q = [...p];
+      else if (name === 'miss') q = [0.6, 0.4, 0, 0];
+      else if (name === 'add') q = [0.45, 0.27, 0.18, 0.1];
+      requestRedraw();
+    };
+    presets.forEach((b) =>
+      b.addEventListener('click', () => {
+        presets.forEach((other) => other.classList.toggle('active', other === b));
+        setPreset(b.dataset.preset);
+      }),
+    );
+
+    const ro = new ResizeObserver(() => { fit(); requestRedraw(); });
+    ro.observe(c);
+    const io = new IntersectionObserver((entries) => {
+      const was = visible;
+      visible = entries[0].isIntersecting;
+      if (visible && !was) { fit(); draw(); }
+    }, { rootMargin: '120px' });
+    io.observe(c);
+  };
+
+  setup();
+  document.addEventListener('astro:page-load', setup);
+  document.addEventListener('astro:after-swap', setup);
+})();
+</script>

--- a/src/components/viz/GrowthRates.astro
+++ b/src/components/viz/GrowthRates.astro
@@ -1,0 +1,187 @@
+---
+interface Props {
+  caption?: string;
+  height?: number;
+}
+const { caption, height = 280 } = Astro.props;
+const id = `gr-${Math.random().toString(36).slice(2, 9)}`;
+---
+<figure class="viz">
+  <div class="viz-controls">
+    <label>
+      violating mass <em style="font-style:normal;color:var(--fg)">S(p, q)</em>
+      <input type="range" min="0" max="1" step="0.01" value="0.3" id={`${id}-s`} aria-label="violating mass S(p,q)" />
+      <span class="readout" id={`${id}-readout`}>S = 0.30</span>
+    </label>
+    <span class="faint" style="margin-left:auto">curves at S = 0.1, 0.5, 1.0 for reference</span>
+  </div>
+  <canvas id={`${id}-c`} height={height} aria-label="Cross-entropy under uniform smoothing for varying violating mass"></canvas>
+  {caption && <figcaption>{caption}</figcaption>}
+</figure>
+
+<script is:inline define:vars={{ id }}>
+(() => {
+  const readColors = () => {
+    const s = getComputedStyle(document.documentElement);
+    const v = (n) => s.getPropertyValue(n).trim();
+    return {
+      accent: v('--accent') || '#b3661b',
+      muted: v('--fg-muted') || '#5a5f66',
+      faint: v('--fg-faint') || '#8d8d8d',
+      border: v('--border') || '#e4e1d6',
+      fg: v('--fg') || '#1a1a1a',
+    };
+  };
+  let colors = readColors();
+
+  const setup = () => {
+    const c = document.getElementById(id + '-c');
+    if (!c || c.dataset.ready) return;
+    c.dataset.ready = '1';
+    const ctx = c.getContext('2d');
+    const slider = document.getElementById(id + '-s');
+    const readout = document.getElementById(id + '-readout');
+
+    let S = 0.3;
+    const state = { dpr: 1, w: 0, h: 0 };
+    const fit = () => {
+      const rect = c.getBoundingClientRect();
+      const dpr = Math.max(1, Math.min(window.devicePixelRatio || 1, 2));
+      state.dpr = dpr;
+      state.w = rect.width;
+      state.h = rect.height;
+      c.width = Math.round(rect.width * dpr);
+      c.height = Math.round(rect.height * dpr);
+    };
+
+    const themeObs = new MutationObserver(() => { colors = readColors(); requestRedraw(); });
+    themeObs.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+
+    let rafScheduled = false;
+    let visible = false;
+    const requestRedraw = () => {
+      if (rafScheduled || !visible) return;
+      rafScheduled = true;
+      requestAnimationFrame(() => { rafScheduled = false; draw(); });
+    };
+
+    const draw = () => {
+      const W = state.w, H = state.h;
+      if (W === 0) return;
+      ctx.setTransform(state.dpr, 0, 0, state.dpr, 0, 0);
+      ctx.clearRect(0, 0, W, H);
+      const { accent, muted, faint, border, fg } = colors;
+
+      const padL = 44, padR = 16, padT = 18, padB = 38;
+      const plotW = W - padL - padR;
+      const plotH = H - padT - padB;
+      // x = ε on log scale from 1e-3 to 1, y = H(p, q^ε) in nats
+      const xMinL = Math.log(1e-3), xMaxL = Math.log(1);
+      const yMin = 0, yMax = 8;
+      const sx = (xL) => padL + ((xL - xMinL) / (xMaxL - xMinL)) * plotW;
+      const sy = (y) => padT + ((yMax - y) / (yMax - yMin)) * plotH;
+
+      // Grid
+      ctx.strokeStyle = border;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      for (let g = 0; g <= 4; g++) {
+        const yy = (g / 4) * yMax;
+        ctx.moveTo(padL, sy(yy)); ctx.lineTo(W - padR, sy(yy));
+      }
+      ctx.stroke();
+
+      // Labels
+      ctx.fillStyle = faint;
+      ctx.font = '10px ui-monospace, monospace';
+      ctx.textAlign = 'right';
+      ctx.textBaseline = 'middle';
+      for (let g = 0; g <= 4; g++) {
+        const yy = (g / 4) * yMax;
+        ctx.fillText(yy.toFixed(0), padL - 4, sy(yy));
+      }
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'top';
+      [1e-3, 1e-2, 1e-1, 1].forEach((e) => {
+        ctx.fillText('10' + (Math.round(Math.log10(e)) === 0 ? '⁰' : '⁻' + ('' + Math.abs(Math.round(Math.log10(e))))), sx(Math.log(e)), H - padB + 6);
+      });
+      ctx.fillStyle = muted;
+      ctx.fillText('smoothing ε  (log scale)', padL + plotW / 2, H - padB + 22);
+      ctx.save();
+      ctx.translate(11, padT + plotH / 2);
+      ctx.rotate(-Math.PI / 2);
+      ctx.textAlign = 'center';
+      ctx.fillText('H(p, q^ε)  (nats)', 0, 0);
+      ctx.restore();
+
+      const C = 0.5; // baseline finite-part constant for visual offset
+
+      const drawCurve = (Sv, color, width, dash) => {
+        ctx.strokeStyle = color;
+        ctx.lineWidth = width;
+        if (dash) ctx.setLineDash(dash); else ctx.setLineDash([]);
+        ctx.beginPath();
+        const M = 200;
+        for (let i = 0; i <= M; i++) {
+          const xL = xMinL + (i / M) * (xMaxL - xMinL);
+          const eps = Math.exp(xL);
+          // H(p, q^ε) ≈ S * (-log ε) + S*log n + C  (n=4 illustrative)
+          const y = Sv * (-Math.log(eps)) + (Sv > 0 ? Sv * Math.log(4) : 0) + C;
+          const yc = Math.min(yMax, Math.max(yMin, y));
+          if (i === 0) ctx.moveTo(sx(xL), sy(yc)); else ctx.lineTo(sx(xL), sy(yc));
+        }
+        ctx.stroke();
+        ctx.setLineDash([]);
+      };
+
+      // Reference curves
+      drawCurve(0.1, muted, 1, [3, 4]);
+      drawCurve(0.5, muted, 1, [3, 4]);
+      drawCurve(1.0, muted, 1, [3, 4]);
+      // S = 0 flat line
+      ctx.strokeStyle = faint;
+      ctx.setLineDash([2, 4]);
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(padL, sy(C)); ctx.lineTo(W - padR, sy(C));
+      ctx.stroke();
+      ctx.setLineDash([]);
+
+      // Labels for reference curves
+      ctx.fillStyle = faint;
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'middle';
+      const labelAtEps = 0.04;
+      const xL0 = Math.log(labelAtEps);
+      [
+        { S: 1.0, label: 'S = 1.0 (disjoint)' },
+        { S: 0.5, label: 'S = 0.5' },
+        { S: 0.1, label: 'S = 0.1' },
+      ].forEach(({ S: Sv, label }) => {
+        const y = Sv * (-Math.log(labelAtEps)) + Sv * Math.log(4) + C;
+        ctx.fillText(label, sx(xL0) + 6, sy(Math.min(yMax - 0.3, y)));
+      });
+      ctx.fillText('S = 0  (finite)', sx(Math.log(0.5)) + 6, sy(C) - 4);
+
+      // Active curve
+      drawCurve(S, accent, 2, null);
+      readout.textContent = 'S = ' + S.toFixed(2)
+        + (S > 0 ? '  · slope = ' + S.toFixed(2) + ' per decade in ε⁻¹' : '  · finite, no divergence');
+    };
+
+    slider.addEventListener('input', () => { S = parseFloat(slider.value); requestRedraw(); });
+    const ro = new ResizeObserver(() => { fit(); requestRedraw(); });
+    ro.observe(c);
+    const io = new IntersectionObserver((entries) => {
+      const was = visible;
+      visible = entries[0].isIntersecting;
+      if (visible && !was) { fit(); draw(); }
+    }, { rootMargin: '120px' });
+    io.observe(c);
+  };
+
+  setup();
+  document.addEventListener('astro:page-load', setup);
+  document.addEventListener('astro:after-swap', setup);
+})();
+</script>

--- a/src/components/viz/VectorVsProbability.astro
+++ b/src/components/viz/VectorVsProbability.astro
@@ -1,0 +1,287 @@
+---
+interface Props {
+  caption?: string;
+  height?: number;
+}
+const { caption, height = 280 } = Astro.props;
+const id = `vvp-${Math.random().toString(36).slice(2, 9)}`;
+---
+<figure class="viz">
+  <div class="viz-controls">
+    <label>
+      support overlap <em style="font-style:normal;color:var(--fg)">o</em>
+      <input type="range" min="0" max="1" step="0.01" value="0" id={`${id}-o`} aria-label="support overlap between p and q" />
+      <span class="readout" id={`${id}-readout`}>o = 0.00  ·  D_KL = ∞</span>
+    </label>
+  </div>
+  <div class="vvp-pair">
+    <div class="vvp-cell">
+      <h4>vector space</h4>
+      <canvas id={`${id}-vec`} height={height} aria-label="Orthogonal vectors with Euclidean distance"></canvas>
+    </div>
+    <div class="vvp-cell">
+      <h4>probability space</h4>
+      <canvas id={`${id}-prob`} height={height} aria-label="Two distributions with adjustable support overlap"></canvas>
+    </div>
+  </div>
+  {caption && <figcaption>{caption}</figcaption>}
+</figure>
+
+<style>
+  .vvp-pair { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; }
+  .vvp-cell h4 {
+    font-family: var(--mono);
+    font-size: 0.74rem;
+    color: var(--fg-muted);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    margin: 0 0 0.35rem;
+    font-weight: 500;
+    text-align: center;
+  }
+  @media (max-width: 640px) { .vvp-pair { grid-template-columns: 1fr; } }
+</style>
+
+<script is:inline define:vars={{ id }}>
+(() => {
+  const readColors = () => {
+    const s = getComputedStyle(document.documentElement);
+    const v = (n) => s.getPropertyValue(n).trim();
+    return {
+      accent: v('--accent') || '#b3661b',
+      muted: v('--fg-muted') || '#5a5f66',
+      faint: v('--fg-faint') || '#8d8d8d',
+      border: v('--border') || '#e4e1d6',
+      fg: v('--fg') || '#1a1a1a',
+    };
+  };
+  let colors = readColors();
+
+  const setup = () => {
+    const cV = document.getElementById(id + '-vec');
+    const cP = document.getElementById(id + '-prob');
+    if (!cV || cV.dataset.ready) return;
+    cV.dataset.ready = '1';
+    cP.dataset.ready = '1';
+    const ctxV = cV.getContext('2d');
+    const ctxP = cP.getContext('2d');
+    const slider = document.getElementById(id + '-o');
+    const readout = document.getElementById(id + '-readout');
+
+    let o = 0; // overlap fraction in [0, 1]
+    const state = { dpr: 1 };
+
+    const fit = () => {
+      const dpr = Math.max(1, Math.min(window.devicePixelRatio || 1, 2));
+      state.dpr = dpr;
+      [cV, cP].forEach((c) => {
+        const rect = c.getBoundingClientRect();
+        c.width = Math.round(rect.width * dpr);
+        c.height = Math.round(rect.height * dpr);
+      });
+    };
+
+    const themeObs = new MutationObserver(() => { colors = readColors(); requestRedraw(); });
+    themeObs.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+
+    let rafScheduled = false;
+    let visible = false;
+    const requestRedraw = () => {
+      if (rafScheduled || !visible) return;
+      rafScheduled = true;
+      requestAnimationFrame(() => { rafScheduled = false; draw(); });
+    };
+
+    const arrow = (ctx, x0, y0, x1, y1, color, w) => {
+      ctx.strokeStyle = color;
+      ctx.fillStyle = color;
+      ctx.lineWidth = w;
+      ctx.beginPath();
+      ctx.moveTo(x0, y0); ctx.lineTo(x1, y1);
+      ctx.stroke();
+      const a = Math.atan2(y1 - y0, x1 - x0);
+      const s = 7;
+      ctx.beginPath();
+      ctx.moveTo(x1, y1);
+      ctx.lineTo(x1 - s * Math.cos(a - 0.4), y1 - s * Math.sin(a - 0.4));
+      ctx.lineTo(x1 - s * Math.cos(a + 0.4), y1 - s * Math.sin(a + 0.4));
+      ctx.closePath();
+      ctx.fill();
+    };
+
+    const drawVec = () => {
+      const ctx = ctxV;
+      const rect = cV.getBoundingClientRect();
+      const W = rect.width, H = rect.height;
+      ctx.setTransform(state.dpr, 0, 0, state.dpr, 0, 0);
+      ctx.clearRect(0, 0, W, H);
+      const { accent, muted, faint, border, fg } = colors;
+      const cx = W / 2, cy = H / 2;
+      const R = Math.min(W, H) * 0.36;
+
+      // Unit circle
+      ctx.strokeStyle = border;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.arc(cx, cy, R, 0, Math.PI * 2);
+      ctx.stroke();
+
+      // Axes
+      ctx.strokeStyle = faint;
+      ctx.setLineDash([2, 4]);
+      ctx.beginPath();
+      ctx.moveTo(cx - R - 12, cy); ctx.lineTo(cx + R + 12, cy);
+      ctx.moveTo(cx, cy - R - 12); ctx.lineTo(cx, cy + R + 12);
+      ctx.stroke();
+      ctx.setLineDash([]);
+
+      // u along +x
+      arrow(ctx, cx, cy, cx + R, cy, accent, 2.2);
+      // v along +y
+      arrow(ctx, cx, cy, cx, cy - R, fg, 2.2);
+
+      // distance bracket from tip of u to tip of v
+      const x1 = cx + R, y1 = cy;
+      const x2 = cx, y2 = cy - R;
+      ctx.strokeStyle = muted;
+      ctx.lineWidth = 1.2;
+      ctx.setLineDash([3, 3]);
+      ctx.beginPath();
+      ctx.moveTo(x1, y1); ctx.lineTo(x2, y2);
+      ctx.stroke();
+      ctx.setLineDash([]);
+
+      // Labels
+      ctx.fillStyle = accent;
+      ctx.font = 'bold 13px ' + (getComputedStyle(document.body).fontFamily || 'serif');
+      ctx.textAlign = 'left'; ctx.textBaseline = 'middle';
+      ctx.fillText('u', x1 + 8, y1 - 2);
+      ctx.fillStyle = fg;
+      ctx.fillText('v⊥', x2 + 6, y2 - 8);
+
+      ctx.fillStyle = muted;
+      ctx.font = '11px ui-monospace, monospace';
+      ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+      const mx = (x1 + x2) / 2;
+      const my = (y1 + y2) / 2;
+      ctx.fillText('d = √2', mx + 18, my - 18);
+
+      // Right angle indicator
+      ctx.strokeStyle = muted;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(cx + 10, cy);
+      ctx.lineTo(cx + 10, cy - 10);
+      ctx.lineTo(cx, cy - 10);
+      ctx.stroke();
+
+      // Footer
+      ctx.fillStyle = faint;
+      ctx.font = '11px ui-monospace, monospace';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'bottom';
+      ctx.fillText('orthogonality is reachable, distance is finite', cx, H - 6);
+    };
+
+    const drawProb = () => {
+      const ctx = ctxP;
+      const rect = cP.getBoundingClientRect();
+      const W = rect.width, H = rect.height;
+      ctx.setTransform(state.dpr, 0, 0, state.dpr, 0, 0);
+      ctx.clearRect(0, 0, W, H);
+      const { accent, muted, faint, border, fg } = colors;
+
+      // 4 categories: A B C D. p mass on {A, B}; q has variable overlap.
+      // At o=0: q on {C, D} (disjoint).
+      // At o=1: q on {A, B} (full overlap).
+      // Interpolate q linearly between (0, 0, 0.5, 0.5) and (0.5, 0.5, 0, 0).
+      const p = [0.5, 0.5, 0, 0];
+      const q = [0.5 * o, 0.5 * o, 0.5 * (1 - o), 0.5 * (1 - o)];
+      const labels = ['A', 'B', 'C', 'D'];
+
+      const padL = 30, padR = 14, padT = 16, padB = 38;
+      const plotW = W - padL - padR;
+      const plotH = H - padT - padB;
+      const n = labels.length;
+      const groupW = plotW / n;
+      const innerPad = groupW * 0.18;
+      const halfW = (groupW - 2 * innerPad) / 2;
+      const xCenter = (i) => padL + groupW * i + groupW / 2;
+      const pX = (i) => xCenter(i) - halfW - 2;
+      const qX = (i) => xCenter(i) + 2;
+      const barW = halfW - 1;
+      const baseY = padT + plotH;
+      const yForP = (v) => baseY - v * plotH * 0.85;
+
+      // baseline
+      ctx.strokeStyle = border;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(padL, baseY); ctx.lineTo(padL + plotW, baseY);
+      ctx.stroke();
+
+      for (let i = 0; i < n; i++) {
+        // p
+        const pH = baseY - yForP(p[i]);
+        ctx.fillStyle = muted + '33';
+        ctx.strokeStyle = muted;
+        ctx.fillRect(pX(i), baseY - pH, barW, pH);
+        ctx.strokeRect(pX(i), baseY - pH, barW, pH);
+        // q
+        const qH = baseY - yForP(q[i]);
+        ctx.fillStyle = accent;
+        ctx.strokeStyle = accent;
+        ctx.fillRect(qX(i), baseY - qH, barW, qH);
+        ctx.strokeRect(qX(i), baseY - qH, barW, qH);
+
+        ctx.fillStyle = faint;
+        ctx.font = '11px ui-monospace, monospace';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'top';
+        ctx.fillText(labels[i], xCenter(i), baseY + 4);
+      }
+
+      // Compute D_KL(p || q) (only over p's support {A, B})
+      // p_i / q_i: if q_i = 0 → ∞
+      let kl = 0;
+      let inf = false;
+      for (let i = 0; i < n; i++) {
+        if (p[i] > 0) {
+          if (q[i] <= 0) { inf = true; break; }
+          kl += p[i] * Math.log(p[i] / q[i]);
+        }
+      }
+
+      // Status label
+      ctx.fillStyle = faint;
+      ctx.font = '11px ui-monospace, monospace';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'bottom';
+      if (inf) {
+        ctx.fillStyle = accent;
+        ctx.fillText('D_KL(p ∥ q) = +∞   ·   disjoint support', W / 2, H - 6);
+      } else {
+        ctx.fillText('D_KL(p ∥ q) = ' + kl.toFixed(3) + ' nats   ·   overlap ' + (o * 100).toFixed(0) + '%', W / 2, H - 6);
+      }
+
+      readout.textContent = 'o = ' + o.toFixed(2) + '   ·   D_KL = ' + (inf ? '+∞' : kl.toFixed(3) + ' nats');
+    };
+
+    const draw = () => { drawVec(); drawProb(); };
+
+    slider.addEventListener('input', () => { o = parseFloat(slider.value); requestRedraw(); });
+    const ro = new ResizeObserver(() => { fit(); requestRedraw(); });
+    ro.observe(cV); ro.observe(cP);
+    const io = new IntersectionObserver((entries) => {
+      const was = visible;
+      visible = entries[0].isIntersecting;
+      if (visible && !was) { fit(); draw(); }
+    }, { rootMargin: '120px' });
+    io.observe(cV);
+  };
+
+  setup();
+  document.addEventListener('astro:page-load', setup);
+  document.addEventListener('astro:after-swap', setup);
+})();
+</script>

--- a/src/content/blog/activations-are-bad-for-geometry.mdx
+++ b/src/content/blog/activations-are-bad-for-geometry.mdx
@@ -7,6 +7,7 @@ tags: [ml, geometry, kernels, interpretability]
 import ActivationGallery from '../../components/viz/ActivationGallery.astro';
 import JacobianWarp from '../../components/viz/JacobianWarp.astro';
 import HighDimCollapse from '../../components/viz/HighDimCollapse.astro';
+import CiteAs from '../../components/CiteAs.astro';
 
 A neural network layer is a map. Its Jacobian decides whether that map preserves geometry — distances, angles, volumes on the data manifold — or destroys it. For the standard form $F(\mathbf{x}) = \phi(\mathbf{W}\mathbf{x} + \mathbf{b})$, with $\phi$ applied coordinatewise, the Jacobian factors as
 
@@ -125,3 +126,15 @@ $$
 with a closed-form RKHS norm $\|f\|^2_{\mathcal{H}_K} = \boldsymbol{\alpha}^\top \mathbf{K} \boldsymbol{\alpha}$. There is no $\mathbf{D}_\phi$ sitting in the middle to collapse rank or saturate the metric. The primitive *is* the geometry; selectivity is implemented *as* geometry; kernel similarity *is* the score.
 
 The pointwise activation is not the price of expressivity. It is the price of refusing to make the primitive a kernel. Pick activations with the same care you pick a loss. They are not there for nonlinearity, and they are not free.
+
+<CiteAs
+  slug="activations-are-bad-for-geometry"
+  title="Activations Are Bad for Geometry"
+  pubDate={frontmatter.pubDate}
+  paper={{
+    title: "Manifolds, Activations, and Lost Geometry: How Pointwise Nonlinearities Break the Map",
+    authors: "Bouhsine, T.",
+    year: 2026,
+    venue: "Unpublished manuscript",
+  }}
+/>

--- a/src/content/blog/attention-is-a-kernel.mdx
+++ b/src/content/blog/attention-is-a-kernel.mdx
@@ -7,6 +7,7 @@ tags: [ml, attention, kernels, interpretability]
 import KernelSmoother from '../../components/viz/KernelSmoother.astro';
 import AttentionPatterns from '../../components/viz/AttentionPatterns.astro';
 import RBFExpansion from '../../components/viz/RBFExpansion.astro';
+import CiteAs from '../../components/CiteAs.astro';
 
 *A reading of self-attention through kernel smoothing and RKHS.*
 
@@ -163,3 +164,15 @@ The MLP lacks those objects natively. Until it has them, every explanation of ML
 ---
 
 *References inline. The kernel-smoother view of attention is due to [Tsai et al.](https://aclanthology.org/D19-1443/), with related developments by [Song et al.](https://ojs.aaai.org/index.php/AAAI/article/view/17172), [Choromanski et al.](https://arxiv.org/abs/2009.14794), [Katharopoulos et al.](https://arxiv.org/abs/2006.16236), and [Han et al.](https://arxiv.org/abs/2210.05794). The Yat kernel is from [Bouhsine, 2026](https://arxiv.org/abs/2605.03262). The superposition framing is from [Elhage et al.](https://transformer-circuits.pub/2022/toy_model/index.html), and the mechanistic interpretability descriptions are from the [circuits thread](https://distill.pub/2020/circuits/zoom-in/) and related work.*
+
+<CiteAs
+  slug="attention-is-a-kernel"
+  title="Attention is Explainable Because it is a Kernel"
+  pubDate={frontmatter.pubDate}
+  paper={{
+    title: "A Universal Reproducing Kernel Hilbert Space from Polynomial Alignment and IMQ Distance",
+    authors: "Bouhsine, T.",
+    year: 2026,
+    arxiv: "2605.03262",
+  }}
+/>

--- a/src/content/blog/not-all-infinities-are-equal.mdx
+++ b/src/content/blog/not-all-infinities-are-equal.mdx
@@ -1,0 +1,125 @@
+---
+title: Not All Infinities Are Equal
+description: The singularity structure of cross-entropy explains hallucination, the modality gap, and why contrastive losses need such big batches.
+pubDate: 2026-02-23
+tags: [ml, information-theory, loss-functions, interpretability]
+---
+import GrowthRates from '../../components/viz/GrowthRates.astro';
+import AsymmetryBars from '../../components/viz/AsymmetryBars.astro';
+import VectorVsProbability from '../../components/viz/VectorVsProbability.astro';
+import CiteAs from '../../components/CiteAs.astro';
+
+Cross-entropy diverges. Everyone knows this. The standard story stops at "if the supports don't overlap, the loss is infinite." That story is incomplete in three ways that turn out to matter.
+
+First, the divergence condition is weaker than "disjoint support." $H(p, q) = +\infty$ requires only that there exist a single coordinate $i$ with $p_i > 0$ and $q_i = 0$ — the supports can overlap on 99% of mass and the loss is still infinite if even one violating coordinate is left uncovered. Worse, the *rate* of divergence is not uniform. It is controlled by the total violating mass $S(p, q)$, which gives a continuous spectrum of "infinities" by severity.
+
+Second, cross-entropy is *asymmetric*. $H(p, q) \neq H(q, p)$, and the asymmetry has a precise operational meaning: missing truth ($q_i = 0$ where $p_i > 0$) is an infinite penalty; adding falsehood ($q_i > 0$ where $p_i = 0$) is a zero penalty. The loss enforces coverage with infinite force and imposes no constraint on precision.
+
+Third, KL divergence is *undefined at independence*. Disjoint support is the probabilistic analog of vector orthogonality. Vector geometry has a perfectly well-defined distance at orthogonal — $\sqrt{2}$ on the unit sphere. Probability geometry has a singularity. The configuration that, geometrically, represents "no shared information" is the configuration where the information-theoretic distance metric breaks.
+
+These three facts compose into the three best-known failure modes of modern machine learning. Hallucination is the rational strategy under cross-entropy's asymmetry. The modality gap in CLIP and SigLIP is the optimization's safe distance from the singularity at orthogonal separation. The 32,768-pair batches required to train InfoNCE-based models are the cost of accumulating gradient signal in the flat region around the singularity. None of these are engineering bugs awaiting better architectures. They are mathematical properties of the loss.
+
+## The singularity is not binary
+
+The textbook condition for $H(p, q) = +\infty$ is "if the supports are disjoint." The actual condition is strictly weaker. Define the violating set
+
+$$
+V_{p, q} = \{ i : p_i > 0 \text{ and } q_i = 0 \},
+$$
+
+and the violating mass $S(p, q) = \sum_{i \in V_{p,q}} p_i$. Then
+
+$$
+H(p, q) = +\infty \iff V_{p, q} \neq \varnothing.
+$$
+
+A single uncovered coordinate is sufficient. Two distributions $p = (0.5, 0.3, 0.2)$ and $q = (0.7, 0.3, 0)$ overlap on 80% of $p$'s mass and still give $H(p, q) = +\infty$. The textbook framing of "disjoint support" is presenting a sufficient condition as if it were necessary and sufficient.
+
+But the binary infinite/finite picture is itself misleading. The *path* to infinity is continuous. If we smooth $q$ uniformly, $q^{(\varepsilon)} = (1 - \varepsilon) q + \varepsilon u$ with $u$ uniform on $|\mathcal{X}| = n$ symbols, then as $\varepsilon \to 0^+$,
+
+$$
+H(p, q^{(\varepsilon)}) = S(p, q) \cdot (-\log \varepsilon) + S(p, q) \log n + C_{p,q} + O(\varepsilon).
+$$
+
+The slope of the divergence in $-\log \varepsilon$ is *exactly* the violating mass $S(p, q)$. The "infinity" of cross-entropy is not a single rate — it is a real-valued function of how much truth $q$ is missing.
+
+<GrowthRates caption="Cross-entropy under uniform smoothing q^(ε) for varying violating mass S(p, q). The slope of the divergence in (−log ε) is exactly S. A model that misses 1% of the truth diverges 100× slower than one that misses everything. The S = 0 case is the flat finite line — no violating coordinates, no divergence. Drag the slider to see how the rate scales with S." />
+
+A model that fails to assign mass to a coordinate $i$ where $p_i = 0.01$ is, in the limit, infinitely wrong. A model that fails on a coordinate where $p_i = 0.9$ is *one hundred times more wrong*, in the precise sense that its loss diverges a hundred times faster as you smooth toward zero. The textbook view collapses these together into "the loss is infinite." The view that lets you reason about which model is worse, and by how much, distinguishes them by $S(p, q)$.
+
+## Missing truth is infinite. Adding falsehood is free.
+
+Cross-entropy is not symmetric: in general $H(p, q) \neq H(q, p)$, and the asymmetry has a precise consequence at the boundary of the simplex. For each coordinate:
+
+$$
+\begin{aligned}
+q_i = 0, \; p_i > 0 \;&\Longrightarrow\; -p_i \log q_i = +\infty \quad \text{(infinite penalty)}, \\
+p_i = 0, \; q_i > 0 \;&\Longrightarrow\; -p_i \log q_i = 0 \quad \text{(zero penalty)}.
+\end{aligned}
+$$
+
+The first case is the model failing to cover a real outcome. The second is the model assigning probability to something that cannot happen. Cross-entropy treats these radically differently: the first is unbounded, the second is exactly zero.
+
+<AsymmetryBars caption="Truth p in muted outline, model q in accent. Drag the top of any q bar, or use the presets. 'match' makes q = p — both cross-entropies are finite and equal to H(p). 'miss truth on C' sets q_C = 0 while p_C > 0 — H(p, q) blows up, H(q, p) stays finite. 'add falsehood on D' gives q mass on a coordinate where p has zero — H(p, q) is essentially unchanged, but H(q, p) blows up. Cross-entropy enforces coverage of p with infinite force; it doesn't care about q's precision." />
+
+The operational reading is sharp. Under cross-entropy training, the rational strategy for an uncertain model is to assign positive probability to *everything*. Missing the one real outcome on which the model assigned zero is the only catastrophe. Spreading some probability on outcomes that don't exist costs nothing. The loss does not penalize hallucination — it penalizes only omission.
+
+This is not a sketch of a possible failure mode. It is the optimal strategy.
+
+A vision-language model that describes ten objects in an image containing five real objects pays *zero* extra cross-entropy for the five hallucinated descriptions, as long as it covered the five real ones. A model that describes only four of the five real objects pays *infinite* cross-entropy for the one it missed. Between "say everything, including made-up things" and "say only what you're sure of," the loss prefers the first by an unbounded margin.
+
+This is also why instruction-tuned models routinely confabulate in the absence of a known answer. The pre-training objective spent every gradient on coverage. Refusal — declining to assign probability mass to a wrong answer — is exactly the behavior the loss has been punishing the entire time.
+
+## Cross-entropy diverges at independence
+
+Both the asymmetry above and the growth-rate story reduce, in the worst case, to the same singularity. The Kullback–Leibler divergence
+
+$$
+D_\text{KL}(p \,\|\, q) = \sum_i p_i \log \frac{p_i}{q_i} = H(p, q) - H(p)
+$$
+
+inherits the singularity directly. $H(p)$ is finite for any distribution on a finite alphabet, so $D_\text{KL}(p \,\|\, q) = +\infty$ exactly when $H(p, q)$ is.
+
+The case of disjoint support is the cleanest example, and the most consequential. Disjoint support is the probabilistic analog of vector orthogonality — two distributions that share no events are like two vectors that share no projection. But the two settings handle this case in incompatible ways.
+
+<VectorVsProbability caption="Left: two orthogonal unit vectors. The Euclidean distance between them is exactly √2 — finite, well-defined, and reached by orthogonal pairs at no special cost. Right: two distributions p and q. The slider controls how much q's support overlaps with p's. At zero overlap, the supports are disjoint and D_KL(p || q) = +∞. As overlap grows, the divergence becomes finite and decreases smoothly. Geometric independence is a configuration with a distance; probabilistic independence is a configuration where the distance metric breaks." />
+
+This is not a notational accident. Cross-entropy and KL were designed to be *finite divergences*, useful as proxies for "how far apart are these distributions." But they only work for distributions in the *interior* of the simplex — distributions with full support. At the boundary of the simplex, where mass goes to zero on some coordinates, the divergence is undefined.
+
+Contrastive losses ignore this. InfoNCE, SimCLR's loss, CLIP's loss, and supervised contrastive learning all want negative pairs to be orthogonal in representation space — they all reach for the boundary as their objective. Each one is built on a divergence that does not exist there.
+
+## The modality gap is a singularity shadow
+
+CLIP and SigLIP train image and text encoders to produce embeddings in a shared unit sphere. The contrastive objective wants matched image-text pairs close together and mismatched pairs far apart, with "far" operationalized as small (eventually negative) cosine similarity. In the distributional reading of the loss, the objective wants the image-embedding distribution and the text-embedding distribution to occupy disjoint regions of the sphere — formally, $\mathrm{supp}(p_\text{img}) \cap \mathrm{supp}(p_\text{txt}) = \varnothing$.
+
+But the loss is *undefined* there. The optimization cannot reach orthogonal separation; the gradient diverges as the objective approaches the boundary. So it settles for *near*-orthogonal clusters separated by a residual distance. That residual distance is the well-documented "modality gap" in CLIP and SigLIP: a persistent shift between image embeddings and text embeddings that no amount of training closes.
+
+The gap is not a bug. It is the optimization's safe distance from the singularity at the configuration it was asked to reach.
+
+The same singularity explains the batch-size hunger. The InfoNCE gradient signal for a negative pair is weighted by its softmax probability. In high dimensions, random unit vectors concentrate at cosine zero with variance $1/d$. The negatives the loss is supposed to push away are almost all *already* near orthogonality, so the gradient on each one is exponentially small. Accumulating useful gradient against a flat region near a singularity is exactly the regime that demands enormous batches. CLIP's 32,768-pair batches and ~4 GB similarity matrices are not the optimal training setup; they are the cost of pushing against a region where the loss surface is barely curved.
+
+## What the singularity actually says
+
+The three observations compose into a single architectural statement. Cross-entropy is a finite-distribution divergence with three structural properties:
+
+1. It diverges as soon as $q$ leaves any of $p$'s support uncovered, at a rate determined by the missing mass.
+2. It treats coverage failures and precision failures *infinitely* asymmetrically.
+3. It is undefined at the configuration that represents genuine independence.
+
+A practitioner can do one of three things with this. **Live with it**, and apply the standard mitigations: label smoothing pulls $q$ off the simplex boundary, temperature scaling slows the gradient near the singularity, support regularization explicitly penalizes the violating mass. **Avoid the boundary**, and design objectives that don't ask for what cross-entropy cannot deliver — SigLIP's bias parameter is exactly this move, since it requires only that mismatched similarities sit below some threshold, not at the limit. **Change the divergence**: Jensen–Shannon is bounded by $\log 2$ everywhere; Wasserstein measures distance under transport rather than overlap; MMD operates in an RKHS and is finite for any pair of distributions. Each removes the singularity at a different structural cost.
+
+What is not an option is pretending the singularity isn't there. Hallucination, the modality gap, and the batch-size scaling are not mysteries — they are the loss landscape, behaving exactly as the loss specifies, at the boundary where the specification was always thin.
+
+The choice is not whether the loss has a singularity. It's whether you know where it is.
+
+<CiteAs
+  slug="not-all-infinities-are-equal"
+  title="Not All Infinities Are Equal"
+  pubDate={frontmatter.pubDate}
+  paper={{
+    title: "On the Singularity Structure of Information-Theoretic Losses",
+    authors: "Bouhsine, T.",
+    year: 2026,
+    venue: "Unpublished manuscript",
+  }}
+/>

--- a/src/content/blog/opposite-is-not-different.mdx
+++ b/src/content/blog/opposite-is-not-different.mdx
@@ -7,6 +7,7 @@ tags: [ml, geometry, contrastive, embeddings]
 import OppositionVsOrthogonality from '../../components/viz/OppositionVsOrthogonality.astro';
 import SharedInfoCurve from '../../components/viz/SharedInfoCurve.astro';
 import SimplexPacking from '../../components/viz/SimplexPacking.astro';
+import CiteAs from '../../components/CiteAs.astro';
 
 A standard assumption in contrastive learning holds that pushing negative pairs to cosine similarity $-1$ achieves "maximal difference." This is wrong, and the cost has been substantial.
 
@@ -76,7 +77,7 @@ $$
 
 and the key fact is its singularity structure: if $\mathrm{supp}(p) \cap \mathrm{supp}(q) = \varnothing$, then $H(p, q) = +\infty$. Disjoint supports are the probabilistic analog of orthogonal vectors — distributions that share no mass, like vectors that share no projection. The cross-entropy singularity is the orthogonality condition lifted into probability.
 
-The same structure shows up directly in classifier weights. For a softmax classifier with logits $z_k = \mathbf{w}_k^\top \mathbf{h}$ and class label $y$, the gradient on wrong-class logits $z_k$ pushes them toward $-\infty$. On the unit sphere the most efficient path to a smaller $z_k$ is $\mathbf{w}_k \perp \mathbf{h}$ — the equilibrium has each wrong-class weight orthogonal to the embedding, not antiparallel to it. The "well-separated representations" that plain cross-entropy classifiers produce without any contrastive auxiliary loss are not a happy accident. They are orthogonal by construction.
+The same structure shows up directly in classifier weights. For a softmax classifier with logits $z_k = \mathbf{w}_k^\top \mathbf{h}$ and class label $y$, the gradient on wrong-class logits $z_k$ pushes them toward $-\infty$. On the unit sphere the loss has competing pressures: $\mathbf{w}_y$ wants to be parallel to $\mathbf{h}$ to maximise $z_y$, and each $\mathbf{w}_k$ with $k \neq y$ wants to be antiparallel to $\mathbf{h}$ to minimise $z_k$. With $n$ classes sharing the same $\mathbf{h}$, the antiparallel target cannot be reached by all $n-1$ wrong-class weights simultaneously — they cannot all be $-\mathbf{h}$. The equilibrium is whatever configuration best balances those pressures subject to mutual diversity of the $\mathbf{w}_k$, and the next section shows that configuration is the regular simplex with $\langle\mathbf{w}_k, \mathbf{h}\rangle = -1/(n-1)$: approximately orthogonal for any non-trivial multi-class problem, exactly orthogonal in the $n \to \infty$ limit, and exactly antiparallel only in the binary case $n = 2$. The "well-separated representations" that plain cross-entropy classifiers produce without any contrastive auxiliary loss are not a happy accident. They are the simplex, sitting where the geometry says it should.
 
 ## The simplex packing result
 
@@ -97,3 +98,15 @@ For $n \ge 3$ the optimal configuration moves rapidly toward orthogonality. $n =
 Every method that targets orthogonality (SigLIP, plain cross-entropy) shares two properties: it aligns with the natural concentration of measure on $\mathbb{S}^{d-1}$, and it achieves comparable or better accuracy with substantially less compute. Every method that targets opposition (SimCLR, CLIP, SupCon) requires enormous batches to overcome the geometric tension between its objective and the high-dimensional sphere it is operating on.
 
 The thesis, in one sentence: the geometry of difference is not opposition; it is orthogonality. The most influential contrastive losses of the past five years spent enormous engineering effort compensating for a single geometric mistake — and the loss that did not make the mistake was sitting beside them the whole time, in the form of plain cross-entropy.
+
+<CiteAs
+  slug="opposite-is-not-different"
+  title="Opposite Is Not Different"
+  pubDate={frontmatter.pubDate}
+  paper={{
+    title: "Opposite ≠ Different: The Orthogonality Thesis",
+    authors: "Bouhsine, T.",
+    year: 2026,
+    venue: "Unpublished manuscript",
+  }}
+/>


### PR DESCRIPTION
## Summary
- New post **Not All Infinities Are Equal** (entropy / singularity structure of cross-entropy) at \`/blog/not-all-infinities-are-equal/\`, pubDate 2026-02-23.
- Three new viz components — \`GrowthRates\`, \`AsymmetryBars\`, \`VectorVsProbability\`.
- New \`CiteAs\` component, wired into all four kernel/geometry posts. Each post now has a copy-to-clipboard BibTeX block for the post itself and for the underlying paper (where one exists).
- Math fix: the softmax-orthogonality paragraph in \`opposite-is-not-different\` was overclaiming the equilibrium. Replaced with the precise simplex statement: \`⟨w_k, h⟩ = −1/(n−1)\`, approximately orthogonal for general multi-class, exactly orthogonal only as \`n → ∞\`, exactly antiparallel only at \`n = 2\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)