### PR TITLE
Add Google Analytics 4

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -15,7 +15,12 @@ import {
   SITE_AUTHOR_JOB_TITLE,
   SITE_SAMEAS,
   SITE_OG_IMAGE,
+  GA4_MEASUREMENT_ID,
 } from '../consts';
+
+// Load GA4 only in production and only when an ID is configured, so local
+// dev never pollutes the analytics property.
+const enableGA = import.meta.env.PROD && !!GA4_MEASUREMENT_ID;
 
 interface BlogPostRef { url: string; title: string; description?: string; pubDate: Date }
 
@@ -294,6 +299,33 @@ const jsonLdNodes = [blogPosting, breadcrumb, website, blogIndex, profilePage].f
 {jsonLdNodes.map((node) => (
   <script type="application/ld+json" set:html={JSON.stringify(node)} />
 ))}
+
+{/* Google Analytics 4 — production only. send_page_view is disabled and we
+    fire page_view on astro:page-load so client-side view-transition
+    navigations are counted (exactly once; the listener is registered once
+    and lives on document, surviving head swaps). */}
+{enableGA && (
+  <>
+    <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${GA4_MEASUREMENT_ID}`}></script>
+    <script is:inline set:html={`
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){ dataLayer.push(arguments); }
+      window.gtag = window.gtag || gtag;
+      if (!window.__ga4Init) {
+        window.__ga4Init = true;
+        gtag('js', new Date());
+        gtag('config', '${GA4_MEASUREMENT_ID}', { send_page_view: false });
+        document.addEventListener('astro:page-load', function () {
+          gtag('event', 'page_view', {
+            page_title: document.title,
+            page_location: location.href,
+            page_path: location.pathname + location.search,
+          });
+        });
+      }
+    `} />
+  </>
+)}
 
 {/* Theme bootstrap — runs before paint to avoid FOUC */}
 <script is:inline>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -21,6 +21,13 @@ export const SITE_SAMEAS: readonly string[] = [
 // Relative to BASE_URL — see src/components/BaseHead.astro for the URL build.
 export const SITE_OG_IMAGE = 'og-default.svg';
 
+// Google Analytics 4 Measurement ID, e.g. 'G-XXXXXXXXXX'. Leave empty to
+// disable. The tag only loads in production builds (see BaseHead.astro), so
+// local dev traffic never reaches GA. Per-post numbers come for free: every
+// post is its own URL, so the GA "Pages and screens" report breaks down by
+// post path automatically.
+export const GA4_MEASUREMENT_ID = '';
+
 // giscus — comments via GitHub Discussions on mlnomadpy/blog.
 // IDs fetched via the GitHub GraphQL API; "Announcements" category chosen
 // because only maintainers + the giscus app can create top-level threads.

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -26,7 +26,7 @@ export const SITE_OG_IMAGE = 'og-default.svg';
 // local dev traffic never reaches GA. Per-post numbers come for free: every
 // post is its own URL, so the GA "Pages and screens" report breaks down by
 // post path automatically.
-export const GA4_MEASUREMENT_ID = '';
+export const GA4_MEASUREMENT_ID = 'G-373438VHJB';
 
 // giscus — comments via GitHub Discussions on mlnomadpy/blog.
 // IDs fetched via the GitHub GraphQL API; "Announcements" category chosen


### PR DESCRIPTION
Wires GA4 (production-only, view-transition aware) and sets the Measurement ID G-373438VHJB.

- send_page_view disabled; page_view fired on astro:page-load so client-side view-transition navigations are counted exactly once.
- Loads only in production builds, so local dev never reaches the property.
- Per-post numbers come for free via GA's Pages-and-screens report (each post is its own URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)