### PR TITLE
Cookie-consent banner + Search Console verification hook

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -16,6 +16,7 @@ import {
   SITE_SAMEAS,
   SITE_OG_IMAGE,
   GA4_MEASUREMENT_ID,
+  GOOGLE_SITE_VERIFICATION,
 } from '../consts';
 
 // Load GA4 only in production and only when an ID is configured, so local
@@ -256,6 +257,7 @@ const jsonLdNodes = [blogPosting, breadcrumb, website, blogIndex, profilePage].f
 <meta name="description" content={description} />
 {seoKeywords.length > 0 && <meta name="keywords" content={seoKeywords.join(', ')} />}
 <meta name="author" content={author} />
+{GOOGLE_SITE_VERIFICATION && <meta name="google-site-verification" content={GOOGLE_SITE_VERIFICATION} />}
 {noindex && <meta name="robots" content="noindex, nofollow" />}
 <link rel="canonical" href={canonical} />
 <link rel="icon" href={`${import.meta.env.BASE_URL}/favicon.svg`} type="image/svg+xml" />
@@ -300,31 +302,54 @@ const jsonLdNodes = [blogPosting, breadcrumb, website, blogIndex, profilePage].f
   <script type="application/ld+json" set:html={JSON.stringify(node)} />
 ))}
 
-{/* Google Analytics 4 — production only. send_page_view is disabled and we
-    fire page_view on astro:page-load so client-side view-transition
-    navigations are counted (exactly once; the listener is registered once
-    and lives on document, surviving head swaps). */}
+{/* Google Analytics 4 — production only, and consent-gated: gtag.js is not
+    loaded and no cookie is set until the visitor accepts (see ConsentBanner).
+    send_page_view is disabled; we fire page_view on astro:page-load so
+    client-side view-transition navigations count exactly once. window.__loadGA
+    is the entry point the banner calls on Accept; it also auto-runs here if a
+    prior visit already granted consent. */}
 {enableGA && (
-  <>
-    <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${GA4_MEASUREMENT_ID}`}></script>
-    <script is:inline set:html={`
+  <script is:inline set:html={`
+    (function () {
+      if (window.__gaSetup) return;
+      window.__gaSetup = true;
+      var GA_ID = '${GA4_MEASUREMENT_ID}';
       window.dataLayer = window.dataLayer || [];
       function gtag(){ dataLayer.push(arguments); }
       window.gtag = window.gtag || gtag;
-      if (!window.__ga4Init) {
-        window.__ga4Init = true;
+
+      // Track whether the first astro:page-load has fired, so a mid-session
+      // Accept can still record the current page.
+      window.__gaFirstLoadDone = window.__gaFirstLoadDone || false;
+      document.addEventListener('astro:page-load', function () { window.__gaFirstLoadDone = true; });
+
+      window.__loadGA = function () {
+        if (window.__gaLoaded) return;
+        window.__gaLoaded = true;
+        var s = document.createElement('script');
+        s.async = true;
+        s.src = 'https://www.googletagmanager.com/gtag/js?id=' + GA_ID;
+        document.head.appendChild(s);
         gtag('js', new Date());
-        gtag('config', '${GA4_MEASUREMENT_ID}', { send_page_view: false });
-        document.addEventListener('astro:page-load', function () {
+        gtag('config', GA_ID, { send_page_view: false });
+        function sendPV() {
           gtag('event', 'page_view', {
             page_title: document.title,
             page_location: location.href,
             page_path: location.pathname + location.search,
           });
-        });
-      }
-    `} />
-  </>
+        }
+        document.addEventListener('astro:page-load', sendPV);
+        // If the initial page-load already happened (accept mid-session),
+        // record this page now; otherwise the listener catches the first one.
+        if (window.__gaFirstLoadDone) sendPV();
+      };
+
+      try {
+        if (localStorage.getItem('analytics-consent') === 'granted') window.__loadGA();
+      } catch (e) {}
+    })();
+  `} />
 )}
 
 {/* Theme bootstrap — runs before paint to avoid FOUC */}

--- a/src/components/ConsentBanner.astro
+++ b/src/components/ConsentBanner.astro
@@ -1,0 +1,109 @@
+---
+import { GA4_MEASUREMENT_ID } from '../consts';
+// Only render the banner when analytics is actually configured. In dev the GA
+// loader is gated off anyway, so the banner has nothing to gate — but it is
+// harmless to show; we hide it in dev to keep local pages clean.
+const showBanner = !!GA4_MEASUREMENT_ID && import.meta.env.PROD;
+---
+{showBanner && (
+  <div id="consent-banner" class="consent-banner" role="dialog" aria-live="polite"
+       aria-label="Analytics consent" hidden>
+    <p class="consent-text">
+      I use Google Analytics to see which posts get read. It sets cookies only
+      if you accept. No ads, no selling data.
+    </p>
+    <div class="consent-actions">
+      <button type="button" id="consent-decline" class="consent-btn consent-decline">Decline</button>
+      <button type="button" id="consent-accept" class="consent-btn consent-accept">Accept</button>
+    </div>
+  </div>
+
+  <script is:inline>
+    (() => {
+      const KEY = 'analytics-consent';
+      const setup = () => {
+        const banner = document.getElementById('consent-banner');
+        if (!banner) return;
+        let choice = null;
+        try { choice = localStorage.getItem(KEY); } catch (e) {}
+        // Already decided → keep hidden.
+        if (choice === 'granted' || choice === 'denied') { banner.hidden = true; return; }
+        banner.hidden = false;
+
+        const decide = (value) => {
+          try { localStorage.setItem(KEY, value); } catch (e) {}
+          banner.hidden = true;
+          if (value === 'granted' && typeof window.__loadGA === 'function') window.__loadGA();
+        };
+        const accept = document.getElementById('consent-accept');
+        const decline = document.getElementById('consent-decline');
+        if (accept && !accept.dataset.bound) {
+          accept.dataset.bound = '1';
+          accept.addEventListener('click', () => decide('granted'));
+        }
+        if (decline && !decline.dataset.bound) {
+          decline.dataset.bound = '1';
+          decline.addEventListener('click', () => decide('denied'));
+        }
+      };
+      setup();
+      document.addEventListener('astro:page-load', setup);
+    })();
+  </script>
+
+  <style>
+    .consent-banner {
+      position: fixed;
+      bottom: 1rem;
+      left: 1rem;
+      right: 1rem;
+      max-width: 30rem;
+      margin-left: auto;
+      z-index: 50;
+      display: flex;
+      flex-direction: column;
+      gap: 0.7rem;
+      padding: 0.95rem 1.1rem;
+      background: var(--bg-elev, #fff);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      box-shadow: 0 6px 24px rgba(0, 0, 0, 0.12);
+      font-family: var(--sans);
+    }
+    .consent-text {
+      margin: 0;
+      font-size: 0.85rem;
+      line-height: 1.5;
+      color: var(--fg-muted);
+    }
+    .consent-actions {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: flex-end;
+    }
+    .consent-btn {
+      font-family: var(--sans);
+      font-size: 0.82rem;
+      padding: 0.4rem 0.95rem;
+      border-radius: 6px;
+      cursor: pointer;
+      border: 1px solid var(--border);
+      transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+    }
+    .consent-decline {
+      background: transparent;
+      color: var(--fg-muted);
+    }
+    .consent-decline:hover { color: var(--fg); border-color: var(--fg-faint); }
+    .consent-accept {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: var(--bg);
+      font-weight: 600;
+    }
+    .consent-accept:hover { filter: brightness(1.05); }
+    @media (max-width: 520px) {
+      .consent-banner { left: 0.6rem; right: 0.6rem; bottom: 0.6rem; }
+    }
+  </style>
+)}

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -28,6 +28,12 @@ export const SITE_OG_IMAGE = 'og-default.svg';
 // post path automatically.
 export const GA4_MEASUREMENT_ID = 'G-373438VHJB';
 
+// Google Search Console site-verification token. From Search Console →
+// add property → URL prefix → "HTML tag" method: paste only the content="..."
+// value here (not the whole tag). Leave empty if verifying another way
+// (e.g. via the Google Analytics method, which works now that GA4 is live).
+export const GOOGLE_SITE_VERIFICATION = '';
+
 // giscus — comments via GitHub Discussions on mlnomadpy/blog.
 // IDs fetched via the GitHub GraphQL API; "Announcements" category chosen
 // because only maintainers + the giscus app can create top-level threads.

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,6 +3,7 @@ import { ClientRouter } from 'astro:transitions';
 import BaseHead from '../components/BaseHead.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+import ConsentBanner from '../components/ConsentBanner.astro';
 
 interface BlogPostRef { url: string; title: string; description?: string; pubDate: Date }
 
@@ -36,6 +37,7 @@ const props = Astro.props;
       <slot />
     </main>
     <Footer />
+    <ConsentBanner />
 
     <script is:inline>
       // Inject a fullscreen toggle button onto every .viz figure on the page.


### PR DESCRIPTION
- GA4 is now consent-gated: no gtag.js load and no cookie until the visitor accepts. Decline = GA never loads; choice persists in localStorage.
- New ConsentBanner component (production-only), styled to the site, view-transition aware.
- GOOGLE_SITE_VERIFICATION const emits the google-site-verification meta tag for Search Console HTML-tag verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)