### PR TITLE
Fix consent banner dismissal

### DIFF
--- a/src/components/ConsentBanner.astro
+++ b/src/components/ConsentBanner.astro
@@ -52,6 +52,9 @@ const showBanner = !!GA4_MEASUREMENT_ID && import.meta.env.PROD;
   </script>
 
   <style>
+    /* Author `display:flex` below would otherwise override the UA [hidden]
+       rule, leaving the banner visible after a choice. This wins on specificity. */
+    .consent-banner[hidden] { display: none !important; }
     .consent-banner {
       position: fixed;
       bottom: 1rem;


### PR DESCRIPTION
.consent-banner { display:flex } overrode the UA [hidden] rule, so Accept/Decline set banner.hidden but the banner never disappeared (GA did load — the banner just stayed up). Adds .consent-banner[hidden]{display:none !important}.

🤖 Generated with [Claude Code](https://claude.com/claude-code)