### PR TITLE
Review precision fixes for Three States + Latent on the Spectrum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ dist/
 .env
 .env.production
 
+# Installed AI agent skills (skills CLI / marketing-skills) — not part of the repo
+.agents/
+skills-lock.json
+
 # LaTeX build intermediates inside papers/
 papers/**/*.aux
 papers/**/*.log

--- a/src/content/blog/latent-on-the-spectrum.mdx
+++ b/src/content/blog/latent-on-the-spectrum.mdx
@@ -106,11 +106,11 @@ Steer it. Below, nine codes descend toward a target similarity you control. With
 
 ## The spectral law: the codebook is the top modes of the kernel
 
-That third panel is the whole post. The best $d$-dimensional codebook for a kernel $S^\star$ is not found by trial and error — it is the **top-$d$ eigenvectors of $S^\star$**, scaled by their eigenvalues. This is classical multidimensional scaling, the same spectral fact behind kernel PCA and Laplacian eigenmaps: to embed a similarity, diagonalise it and keep the strongest modes.
+That third panel is the whole post. Ignore the unit-norm renormalisation for a moment: the best rank-$d$ approximation to the Gram matrix is $U_d\Lambda_d U_d^\top$, and a coordinate matrix that realises it is $\Lambda_d^{1/2}U_d^\top$ — the **top-$d$ eigenvectors of $S^\star$, scaled by the square roots of their eigenvalues**. If we want cosine codes we normalise those vectors afterward, which makes the exact Eckart–Young optimum a design principle rather than the literal constrained minimiser. This is classical multidimensional scaling, the same spectral fact behind kernel PCA and Laplacian eigenmaps: to embed a similarity, diagonalise it and keep the strongest modes.
 
 So a kernel's **eigenspectrum** tells you everything about how it wants to be embedded:
 
-- A **flat spectrum** — all eigenvalues equal — is a kernel with no preferred direction. Every mode matters the same. That is the white kernel, and its embedding is the maximally even one: **the simplex** (a tight frame is exactly the flat-spectrum condition from the Welch post). Slide structure to 0 above and watch all the bars snap to the same height.
+- A **flat spectrum on the centered label subspace** — all non-mean modes equal — is a kernel with no preferred direction among classes. (A regular-simplex Gram, once centered, has one zero mean-direction eigenvalue and $C-1$ equal nonzero ones, so "flat" means flat across those $C-1$ class modes, not all $C$.) Every class mode matters the same. That is the white kernel, and its embedding is the maximally even one: **the simplex** (a tight frame is exactly the flat-spectrum condition from the Welch post). Slide structure to 0 above and watch all the bars snap to the same height.
 - A **peaked spectrum** — a few large eigenvalues, the rest small — is a kernel with dominant structure. The top mode is the coarsest distinction (animals vs vehicles); the next modes are finer. Slide structure up and watch one bar shoot up.
 
 The simplex was never the universal answer. It was the answer for the one spectrum that has no shape.
@@ -155,7 +155,7 @@ $$
 \Sigma_{\text{total}} = \underbrace{\Sigma_B}_{\text{between prototypes}} \;+\; \underbrace{\Sigma_W}_{\text{within / residual}} .
 $$
 
-$\Sigma_B$ has rank $\le C-1$ and is spanned by the prototypes — **its geometry is the codebook**, the simplex or Welch frame or structured kernel we've been steering. $\Sigma_W$ is everything else: the within-class variation, the fine distinctions, the gradations between classes. Stack them and a representation's eigenspectrum has two regimes — the **top $C-1$ modes are the prototype frame** (the separation channel), and the **tail is the information**.
+$\Sigma_B$ has rank $\le C-1$ and is spanned by the prototypes — **its geometry is the codebook**, the simplex or Welch frame or structured kernel we've been steering. $\Sigma_W$ is everything else: the within-class variation, the fine distinctions, the gradations between classes. Stack them and a representation's eigenspectrum splits into two regimes — the **top $C-1$ modes are the prototype frame** (the separation channel), and the **tail is the information**. The split is clean only when the between-class variance dominates, as it does near neural collapse; when within-class variance is large the two regimes overlap and "top $C-1$" is an approximation, not a hard cut.
 
 Press Play and watch what training does to it. As the network collapses — $\Sigma_W \to 0$, the celebrated *neural collapse* — the information tail is ground to nothing. The clusters get tighter, the prototypes lock into their frame, and the spectrum the features lived in is erased. Drag **label structure** to shape the prototype modes: flat for a simplex, peaked for a taxonomy.
 
@@ -165,7 +165,7 @@ This is the trade-off the [modality-gap post](/blog/modality-gap-complementary/)
 
 ## Information is a coordinate between prototypes
 
-So where, exactly, does that information live? **Between the prototypes.** Project a feature onto the prototype frame and you get its *soft assignment* — how much it leans toward each code. A feature halfway between `cat` and `dog` reads "70% cat, 30% dog, 0% car." That vector is not noise around the label; it **is** the information — and it is exactly the **dark knowledge** a teacher distills (Hinton et al., 2015). The codebook is the basis; the information is the **coefficients**.
+So where, exactly, does that information live? **Between the prototypes.** Project a feature onto the prototype frame and you get its *soft assignment* — how much it leans toward each code. A feature halfway between `cat` and `dog` reads "70% cat, 30% dog, 0% car." That vector is not noise around the label; it **is** the information — and it is exactly the **dark knowledge** a teacher distills (Hinton et al., 2015). In this frame view, the information shows up as the **coefficients**: the soft mixture of nearby prototypes. (When the prototypes are overcomplete or non-orthogonal, those coefficients are pinned down only once you fix a decoding rule — a dual frame, or a logits/softmax convention.)
 
 Watch a feature wander the frame and read its coordinates:
 

--- a/src/content/blog/three-states-of-information.mdx
+++ b/src/content/blog/three-states-of-information.mdx
@@ -86,6 +86,8 @@ Watch a network train for long enough and the loss curve stops looking like a sm
 
 The cleanest way to see why is to stop watching the loss and watch the *representation*, the geometry of the activations the network is shaping. That geometry moves through three states, and the move from one to the next is exactly the plateau.
 
+By "information" here I mean label-relevant structure in representation space: not Shannon information in the abstract, but the geometry that makes classes recoverable.
+
 <StateMorph caption="The three states on a loop: a real 2-D force system, integrated live. Satellites are pulled toward their class leader (clustering); leaders repel each other and seek a ring (spreading). From a random scatter the system passes through RANDOM → ORGANIZED → STRUCTURED and then re-randomizes. The badge reads the state off the geometry; nothing about the labels is scripted." />
 
 ## Three states, like matter
@@ -102,11 +104,11 @@ The figure below is a supervised contrastive encoder trained live in your browse
 
 <InformationStates caption="A live contrastive training run, on the nanograd autodiff engine. Points are class blobs mapped onto the circle; the badge reads the current state from the geometry. RANDOM: scattered, no class structure. ORGANIZED: same-class points cluster, but the clusters are bunched, not spread. STRUCTURED: the clusters settle into a maximally-separated simplex (min class-pair cosine → −1/(K−1)). Notice that the structure curve (green) rises through the slow stretch of the loss (orange): the reorganization happens during the plateau, then the loss falls." />
 
-That two-step is not incidental to contrastive learning; it is its decomposition. Wang & Isola (2020) show the contrastive loss splits into **alignment**, pulling positive pairs together (the organized state), and **uniformity**, spreading features evenly on the sphere (the structured state). Watching the run above is watching alignment resolve first, then uniformity slowly break the symmetry into a simplex.
+That two-step mirrors the standard decomposition of contrastive learning into alignment and uniformity. Wang & Isola (2020) show the contrastive loss splits into **alignment**, pulling positive pairs together (the organized state), and **uniformity**, spreading features evenly on the sphere (the structured state). That decomposition is about which two properties the loss optimizes, not a guaranteed training-time order; but in the run above you can watch alignment resolve first, then uniformity slowly break the symmetry into a simplex.
 
 ## The plateau is the phase transition
 
-Here is the part that connects the two pictures. The representation does not move between states at a constant rate. It stalls near *saddle points* of the loss: configurations that are flat in most directions, where the gradient is tiny. The network creeps along until some symmetry breaks and it falls toward the next state. That creep is the plateau; the symmetry-breaking is the drop.
+Here is the part that connects the two pictures, in the feature-learning regimes this post is about. The representation does not move between states at a constant rate. It stalls near *saddle points* of the loss: configurations that are flat in most directions, where the gradient is tiny. The network creeps along until some symmetry breaks and it falls toward the next state. That creep is the plateau; the symmetry-breaking is the drop.
 
 <SaddleDescent caption="The mechanism, in miniature: real gradient descent on a surface with a saddle at the origin (a minimum along one axis, a maximum along the other). The trajectory drops fast in the steep direction, then creeps across the flat saddle where the gradient is nearly zero (that creep is the plateau) before the instability takes over and it falls into a basin. The loss trace on the right shows the same flat-then-drop." />
 
@@ -132,9 +134,9 @@ Once you see plateaus as transitions between the three states, a few practical r
 
 **A plateau is a question, not a failure.** Before killing a run that has flattened, ask which transition it is stuck on. Is the representation random (still no clusters, so maybe the signal is too weak), or organized but not structured (clusters formed but not yet separated, often a symmetry waiting to break)? The two call for different fixes.
 
-**Structure can lead the loss.** As the first figure shows, the geometry often reorganizes *during* the plateau, before the loss moves. If you only watch the loss you will miss it; a cheap structure probe (within-class tightness, between-class separation, distance to the simplex/Welch bound) sees the transition coming.
+**Structure can lead the loss.** As the first figure shows, the geometry often reorganizes *during* the plateau, before the loss moves. If you only watch the loss you will miss it; a cheap structure probe sees the transition coming. Concretely, during a plateau log three numbers: intra-class variance, mean inter-class cosine similarity, and the distance from the class-mean Gram matrix to a simplex ETF. If intra-class variance is still falling, the network is organizing; if the class means are drifting toward equiangularity, it is structuring.
 
-**The destination is a simplex.** The structured state is not arbitrary. For a classification or contrastive objective it is the maximally-separated, equiangular arrangement: the simplex ETF of neural collapse, the saturating configuration of the Welch bound. This is the same endpoint these posts keep arriving at from different directions: [a good latent space](/blog/welch-bound-good-latent-space/) is a structured one, and [organizing randomness](/blog/organizing-randomness-jax/) is the process of getting there.
+**The destination is a simplex, in the clean limit.** The structured state is not arbitrary. In the balanced supervised-classification limit it is the maximally-separated, equiangular arrangement: the simplex ETF of neural collapse, the saturating configuration of the Welch bound. More generally the endpoint is a globally constrained code whose geometry reflects the objective, the labels, and the data: hierarchy, class imbalance, and multi-label structure all bend it away from the plain simplex. But the *kind* of endpoint is the same one these posts keep arriving at from different directions: [a good latent space](/blog/welch-bound-good-latent-space/) is a structured one, and [organizing randomness](/blog/organizing-randomness-jax/) is the process of getting there.
 
 ## The point
 


### PR DESCRIPTION
Apply reviewer precision/scope edits to both newly-published posts (spectral scaling, flat-spectrum subspace, two-regime conditioning, alignment/uniformity framing, simplex-in-the-clean-limit, concrete plateau probes). Also gitignore the installed .agents skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)