### PR TITLE
Add separate writeups section

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -10,6 +10,7 @@ const isActive = (href: string) => {
 };
 const links = [
   { href: `${base}/`, label: 'posts' },
+  { href: `${base}/writeups`, label: 'writeups' },
   { href: `${base}/search`, label: 'search' },
   { href: `${base}/tags`, label: 'tags' },
   { href: `${base}/about`, label: 'about' },

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -41,4 +41,24 @@ const blog = defineCollection({
   }),
 });
 
-export const collections = { blog };
+// Personal writeups — opinions, notes, and reflections that are deliberately
+// kept separate from the AI-theory `blog` collection. They live at
+// /blog/writeups/, have their own listing + RSS feed, and do NOT share the
+// blog's tag pages, related-posts, or companion machinery. Schema is a lean
+// subset of `blog`: just enough for a dated essay with optional tags.
+const writeups = defineCollection({
+  loader: glob({ pattern: '**/*.{md,mdx}', base: './src/content/writeups' }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string().optional(),
+    seoDescription: z.string().optional(),
+    pubDate: z.coerce.date(),
+    updatedDate: z.coerce.date().optional(),
+    tags: z.array(z.string()).default([]),
+    keywords: z.array(z.string()).optional(),
+    draft: z.boolean().default(false),
+    heroImage: z.string().optional(),
+  }),
+});
+
+export const collections = { blog, writeups };

--- a/src/content/writeups/building-spaceships-and-surviving-floods.mdx
+++ b/src/content/writeups/building-spaceships-and-surviving-floods.mdx
@@ -1,0 +1,38 @@
+---
+title: On building spaceships and surviving floods
+description: When you believe a flood is coming, the only way to survive is to build the ship, even when no one believes you. So you pick up the hammer.
+pubDate: 2026-06-15
+tags: [notes, conviction, building]
+---
+
+There's a kind of knowing that arrives before the evidence does.
+
+You feel the flood coming. You can't prove it yet. The sky is clear, the
+ground is dry, and everyone around you is going about their day. But you know.
+And once you know, there's only one thing to do: build the ship.
+
+No one believes you. They never do. To them you're the strange one, hammering
+away at something that doesn't make sense for weather that isn't here. That's
+fine. You don't build for them. You learn to listen only to the other
+believers, the few who feel the same thing in their bones, who showed up not to
+argue but to survive.
+
+Every piece of the ship has to be perfect.
+
+That's the part people get wrong. They think you can cut a corner here, soften a
+plank there, file down the parts that make others uncomfortable, bend the ship
+to fit someone's ideology, someone's goals, someone's idea of how things are
+supposed to look. You can't. You *know* that piece matters. You know it's load-
+bearing when the water comes. Every piece is. Each one belongs to the people who
+believed, the people who'll be standing on this deck when the rest of the world
+is under water. You don't owe that piece to anyone who wasn't going to get on
+board anyway.
+
+I'm no Noah. I won't pretend to be. But I believe, really believe, that we'll
+soon need to build the spaceship.
+
+Maybe I don't know how. Maybe I'll get pieces wrong and have to tear them out and
+start again. The goal was never to already know how. The goal is to *try* to
+build it. Because if I don't, no one will. No one can. No one cares.
+
+So I pick up the hammer.

--- a/src/content/writeups/why-writeups.mdx
+++ b/src/content/writeups/why-writeups.mdx
@@ -1,0 +1,22 @@
+---
+title: Why a separate corner for writeups
+description: A place for my own thoughts — opinions, notes, half-formed ideas — kept apart from the AI theory.
+pubDate: 2026-06-15
+tags: [meta, notes]
+draft: true
+---
+
+The blog is for the work: kernels, attention, the geometry of representations —
+things I can defend with a proof or a plot.
+
+This is for everything else. Opinions I haven't pressure-tested. Notes from the
+road. Half-formed ideas I want out of my head and onto a page. Things that are
+true for me today and might not be next year.
+
+I kept them apart on purpose. When a theory post and a personal rant share a
+feed, both get worse — the theory feels softer, the rant feels like it's
+pretending to be rigorous. So: two doors. Walk through whichever one you came
+for.
+
+This first one is a draft — it won't show up on the published site until I drop
+`draft: true`. Delete this file whenever you write the real first one.

--- a/src/layouts/WriteupLayout.astro
+++ b/src/layouts/WriteupLayout.astro
@@ -1,0 +1,100 @@
+---
+import BaseLayout from './BaseLayout.astro';
+import Giscus from '../components/Giscus.astro';
+import CodeCopy from '../components/CodeCopy.astro';
+import ReadingProgress from '../components/ReadingProgress.astro';
+
+// Standalone layout for the personal `writeups` collection. Intentionally lean
+// and self-contained: no companion callouts, no references list, no tag-page
+// links, no related-posts rail. These are personal notes, kept apart from the
+// AI-theory blog post layout so the two never bleed into one another.
+interface Props {
+  title: string;
+  description?: string;
+  draft?: boolean;
+  pubDate: Date;
+  updatedDate?: Date;
+  tags?: string[];
+  keywords?: string[];
+  heroImage?: string;
+  readingTimeText?: string;
+  wordCount?: number;
+}
+const {
+  title,
+  description,
+  draft,
+  pubDate,
+  updatedDate,
+  tags = [],
+  keywords,
+  heroImage,
+  readingTimeText,
+  wordCount,
+} = Astro.props;
+const dateFmt = new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+---
+<BaseLayout
+  title={title}
+  description={description}
+  image={heroImage}
+  type="article"
+  pubDate={pubDate}
+  updatedDate={updatedDate}
+  tags={tags}
+  keywords={keywords}
+  wordCount={wordCount}
+>
+  <ReadingProgress />
+  <article data-blog-post>
+    <header class="post-header">
+      <p class="kicker"><a href={`${base}/writeups/`}>writeups</a></p>
+      {draft && <p class="draft-banner">Draft — visible locally, excluded from the published site</p>}
+      <h1>{title}</h1>
+      <p class="meta">
+        <time datetime={pubDate.toISOString()}>{dateFmt.format(pubDate)}</time>
+        {updatedDate && <> · updated <time datetime={updatedDate.toISOString()}>{dateFmt.format(updatedDate)}</time></>}
+        {readingTimeText && <> · {readingTimeText}</>}
+      </p>
+      {tags.length > 0 && (
+        <p class="tag-row">
+          {tags.map((t) => <span class="tag">#{t}</span>)}
+        </p>
+      )}
+    </header>
+    <slot />
+    <p class="back-link"><a href={`${base}/writeups/`}>← all writeups</a></p>
+  </article>
+  <Giscus />
+  <CodeCopy />
+</BaseLayout>
+
+<style>
+  .kicker {
+    font-family: var(--mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    margin: 0 0 0.5rem;
+  }
+  .kicker a { color: var(--fg-faint); text-decoration: none; }
+  .kicker a:hover { color: var(--accent); }
+  .tag-row { margin-top: 0.65rem; }
+  .tag-row .tag {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 0.72rem;
+    color: var(--fg-muted);
+    margin-right: 0.6rem;
+  }
+  .back-link {
+    margin-top: 3rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    font-family: var(--mono);
+    font-size: 0.82rem;
+  }
+  .back-link a { color: var(--fg-faint); text-decoration: none; }
+  .back-link a:hover { color: var(--accent); }
+</style>

--- a/src/pages/writeups/[...slug].astro
+++ b/src/pages/writeups/[...slug].astro
@@ -1,0 +1,32 @@
+---
+import { getCollection, render } from 'astro:content';
+import readingTime from 'reading-time';
+import WriteupLayout from '../../layouts/WriteupLayout.astro';
+import { postFilter } from '../../utils/posts';
+
+export async function getStaticPaths() {
+  const writeups = await getCollection('writeups', postFilter);
+  return writeups.map((post) => ({
+    params: { slug: post.id },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+const stats = readingTime(post.body ?? '');
+---
+<WriteupLayout
+  title={post.data.title}
+  description={post.data.seoDescription ?? post.data.description}
+  draft={post.data.draft}
+  pubDate={post.data.pubDate}
+  updatedDate={post.data.updatedDate}
+  tags={post.data.tags}
+  keywords={post.data.keywords}
+  heroImage={post.data.heroImage}
+  readingTimeText={stats.text}
+  wordCount={stats.words}
+>
+  <Content />
+</WriteupLayout>

--- a/src/pages/writeups/index.astro
+++ b/src/pages/writeups/index.astro
@@ -1,0 +1,131 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { getCollection } from 'astro:content';
+import { SITE_TITLE } from '../../consts';
+import { postFilter } from '../../utils/posts';
+
+const writeups = (await getCollection('writeups', postFilter))
+  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+
+const byYear = writeups.reduce<Record<number, typeof writeups>>((acc, p) => {
+  const y = p.data.pubDate.getFullYear();
+  (acc[y] ??= []).push(p);
+  return acc;
+}, {});
+const years = Object.keys(byYear).map(Number).sort((a, b) => b - a);
+const fmt = new Intl.DateTimeFormat('en-US', { month: 'short', day: '2-digit' });
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+---
+<BaseLayout
+  title={`Writeups · ${SITE_TITLE}`}
+  description="Personal writeups — opinions, notes, and reflections that aren't AI theory. The unpolished, off-the-cuff side."
+>
+  <section class="intro">
+    <h1>Writeups</h1>
+    <p class="intro-blurb">
+      My own thoughts — opinions, notes from the road, half-formed ideas.
+      Not theory, not peer-reviewed, not always right. The
+      <a href={`${base}/`}>blog</a> is for the ML; this is for everything else.
+    </p>
+  </section>
+
+  {writeups.length === 0 ? (
+    <p class="empty">Nothing here yet.</p>
+  ) : (
+    <section class="archive">
+      {years.map((year) => (
+        <div class="archive-year">
+          <h2>{year}</h2>
+          <ul>
+            {byYear[year].map((post) => (
+              <li>
+                <a class="row" href={`${base}/writeups/${post.id}/`}>
+                  <time class="row-date" datetime={post.data.pubDate.toISOString()}>
+                    {fmt.format(post.data.pubDate)}
+                  </time>
+                  <span class="row-title">
+                    {post.data.draft && <span class="draft-badge">draft</span>}
+                    {post.data.title}
+                  </span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </section>
+  )}
+</BaseLayout>
+
+<style>
+  .intro-blurb {
+    margin: 0.85rem 0 0.5rem;
+    font-size: 0.96rem;
+    line-height: 1.6;
+    color: var(--fg-muted);
+    max-width: 56ch;
+  }
+  .intro-blurb a { color: var(--accent); }
+  .empty { color: var(--fg-faint); font-style: italic; margin-top: 1.5rem; }
+  .archive { margin-top: 1.5rem; }
+  .archive-year { margin-bottom: 1.75rem; }
+  .archive-year h2 {
+    font-family: var(--mono);
+    font-size: 0.78rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--fg-faint);
+    font-weight: 500;
+    margin: 0 0 0.4rem;
+    padding-bottom: 0.45rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .archive-year ul { list-style: none; padding: 0; margin: 0; }
+  .archive-year li { border-bottom: 1px dashed var(--border); }
+  .archive-year li:last-child { border-bottom: 0; }
+  .row {
+    display: grid;
+    grid-template-columns: 72px minmax(0, 1fr);
+    gap: 1rem;
+    align-items: baseline;
+    padding: 0.6rem 0;
+    text-decoration: none;
+    color: inherit;
+  }
+  .row-date {
+    font-family: var(--mono);
+    font-size: 0.78rem;
+    color: var(--fg-faint);
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+  .row-title {
+    font-family: var(--serif);
+    font-size: 1.02rem;
+    line-height: 1.4;
+    color: var(--fg);
+    transition: color var(--transition-fast);
+  }
+  .row:hover .row-title { color: var(--accent); }
+  .draft-badge {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 0.62rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--accent);
+    border: 1px solid var(--accent);
+    border-radius: 4px;
+    padding: 0.05rem 0.35rem;
+    margin-right: 0.5rem;
+    vertical-align: 0.12em;
+  }
+  @media (max-width: 720px) {
+    .row {
+      grid-template-columns: 56px 1fr;
+      gap: 0.75rem;
+      padding: 0.7rem 0;
+    }
+  }
+</style>

--- a/src/pages/writeups/rss.xml.ts
+++ b/src/pages/writeups/rss.xml.ts
@@ -1,0 +1,25 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import { SITE_TITLE } from '../../consts';
+import { postFilter } from '../../utils/posts';
+import type { APIContext } from 'astro';
+
+// Separate feed for the personal writeups collection, so subscribers to the
+// AI-theory blog (/blog/rss.xml) and the writeups (/blog/writeups/rss.xml)
+// never get mixed streams.
+export async function GET(context: APIContext) {
+  const writeups = await getCollection('writeups', postFilter);
+  return rss({
+    title: `${SITE_TITLE} — Writeups`,
+    description: 'Personal writeups — opinions, notes, and reflections that aren’t AI theory.',
+    site: context.site!,
+    items: writeups
+      .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
+      .map((post) => ({
+        title: post.data.title,
+        description: post.data.description ?? '',
+        pubDate: post.data.pubDate,
+        link: `/writeups/${post.id}/`,
+      })),
+  });
+}


### PR DESCRIPTION
Adds a **writeups** section at `/blog/writeups/`, deliberately walled off from the AI-theory blog.

## What's separate
- New `writeups` content collection (lean schema, no companion/references machinery)
- Own listing page, post route, and RSS feed (`/blog/writeups/rss.xml`)
- Dedicated `WriteupLayout` — no related-posts, companion callouts, or blog tag-page links
- Nav link added to the header

## Content
- First writeup: *On building spaceships and surviving floods*
- A `draft: true` placeholder (`why-writeups.mdx`) that stays hidden in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)