### PR TITLE
Add writeup: Am I Building the Ship, or the Flood?

### DIFF
--- a/src/content/writeups/am-i-building-the-ship-or-the-flood.mdx
+++ b/src/content/writeups/am-i-building-the-ship-or-the-flood.mdx
@@ -1,0 +1,63 @@
+---
+title: "Am I Building the Ship, or the Flood?"
+description: "A follow-up to the flood. The doubt that arrives after you pick up the hammer: what if the thing I am building is not the ark, but the rain?"
+pubDate: 2026-06-16
+tags: [notes, ai, doubt]
+---
+
+A while ago I wrote that when you feel the flood coming, the only thing to do is
+[build the ship](/blog/writeups/building-spaceships-and-surviving-floods/). I
+picked up the hammer. I meant it.
+
+Now I lie awake with a different question.
+
+What if I am not building the ship? What if the thing taking shape under my hands
+is not an ark but a cloud machine, a thing that pulls the storm in tighter, that
+makes the water rise faster for everyone who is not standing on it? You can
+hammer in good faith and still be building the rain. The believer and the
+accelerant look identical from the inside. Both are certain. Both are working
+hard. Both think they are saving someone.
+
+So I have to ask the question the first plank never made me ask. Is it still wise
+to keep building? Or is it time to set the hammer down for a while and watch how
+the world plays out, to let the thing show me what it is before I add another
+piece to it?
+
+I used to think the answer was obvious. Keep going. If I don't, no one will. But
+"keep going" quietly assumes I can trust the hands the work passes into. And I am
+less sure of that than I have ever been.
+
+Because here is what I keep hearing now. "ChatGPT told me to do it this way."
+"This is what Claude said." A whole way of talking where the human has stepped
+out of their own sentence, where the judgment that used to belong to a person got
+subcontracted to a machine and the person is left as the courier. (No Gemini line
+here, I will spare it. slop is slop.) It sounds like deference. It is an
+abdication. The model did not decide. It cannot decide. It has no skin, no stake,
+no one to face in the morning. But it is very good at letting a human pretend the
+deciding already happened somewhere else.
+
+That scares me more than any capability on any roadmap.
+
+Is morality dead, or only outrun? Philosophy moves at the speed of a careful
+argument; the technology moves at the speed of a deploy. We are shipping decisions
+faster than we can reason about whether they are good, and "we will figure out the
+ethics later" has become the load-bearing beam of a whole industry. Later does not
+come. Later is just a place we keep building over.
+
+Are we ready for a world where humans are not the ones making the decisions?
+Because we are not in that world yet. We are in the more dangerous one, the
+in-between, where the human still signs the decision but no longer makes it, where
+authorship and accountability have come apart and almost no one has noticed,
+because the output still looks like it came from a person.
+
+I do not have the clean ending the first piece had. I cannot tell you to pick up
+the hammer with the same certainty I had then.
+
+What I can tell you is that the doubt is not a reason to stop. The doubt is the
+piece. A ship built by someone who never once asked whether he was building the
+flood is exactly the ship I would not board. So maybe the most important plank is
+the question itself, kept sharp, asked again every morning before the first nail:
+am I building the ship, or the rain?
+
+I still do not fully know. But I would rather build while afraid of that question
+than build without ever asking it.


### PR DESCRIPTION
A follow-up to *On building spaceships and surviving floods* — the doubt that arrives after picking up the hammer: builder vs accelerant, outsourced judgment ("Claude told me to"), morality outrun by deploys, and the in-between world where humans still sign decisions they no longer make.

Lands at `/blog/writeups/am-i-building-the-ship-or-the-flood` and links back to the flood piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)