### PR TITLE
Add post: What a Finite Kernel Buys an MLP (+6 live viz)

### DIFF
--- a/src/components/viz/FeatureLearningFlow.astro
+++ b/src/components/viz/FeatureLearningFlow.astro
@@ -1,0 +1,151 @@
+---
+interface Props {
+  caption?: string;
+  height?: number;
+}
+const { caption, height = 420 } = Astro.props;
+---
+<figure class="viz featflow" data-caption={caption} data-height={height} tabindex="0">
+  <div class="viz-cell"></div>
+</figure>
+
+<script>
+// Why a prototype moves — the force field of feature learning, computed live on
+// the nanograd engine. A prototype wants to become a detector for one class: the
+// objective rewards kernel response to that class and penalises the other. The
+// negative gradient of that objective is a force on the prototype's position, and
+// we draw it as a field. Drop the probe anywhere and it flows along the field onto
+// the data it should explain. There is force everywhere — no half-space where the
+// gradient is zero — which is exactly why a Yat unit never dies the way a ReLU
+// unit can. Real autodiff: each arrow is a backward pass.
+import { defineViz } from './engine/vizkit.js';
+import { arrow } from './engine/draw.js';
+import * as ng from './engine/nanograd.js';
+import { rng32 } from './engine/datasets.js';
+
+const B = 0.5, EPS = 0.4, PAD = 10;
+const DOM = 2.1, GRID = 13;
+
+defineViz('featflow', {
+  title: 'Why a prototype moves',
+  height: 420, stepsPerFrame: 1, autoplay: true,
+  controls: [
+    { type: 'play' }, { type: 'step' }, { type: 'button', name: 'drop', label: 'new drop', reset: false },
+    { type: 'readout', name: 'rd' },
+  ],
+
+  setup(api) {
+    const r = rng32(3);
+    const randn = () => { let u = 0, v = 0; while (!u) u = r(); while (!v) v = r(); return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v); };
+    const N = 90; const X = new Float64Array(N * 2), lab = new Int8Array(N);
+    const mA = new Float64Array(N), mB = new Float64Array(N); let nA = 0, nB = 0;
+    for (let i = 0; i < N; i++) {
+      const c = i < N / 2 ? 0 : 1;
+      X[i * 2] = (c ? 1 : -1) * 1.0 + randn() * 0.32; X[i * 2 + 1] = (c ? -0.5 : 0.5) + randn() * 0.4;
+      lab[i] = c; if (c === 0) { mA[i] = 1; nA++; } else { mB[i] = 1; nB++; }
+    }
+    const Xd = ng.tensor(N, 2, X), MA = ng.tensor(N, 1, mA), MB = ng.tensor(N, 1, mB);
+
+    // force = −∇_P L,  L = meanB κ(P,·) − meanA κ(P,·)   (descend → become an A-detector)
+    const forceAt = (px, py) => {
+      const P = ng.param(1, 2, (i) => (i === 0 ? px : py));
+      const dot = ng.matmul(Xd, ng.transpose(P));
+      const dist2 = ng.sumRows(ng.square(ng.sub(Xd, P)));
+      const ker = ng.div(ng.square(ng.addk(dot, B)), ng.addk(dist2, EPS));
+      const meanA = ng.mulk(ng.sumAll(ng.mul(ker, MA)), 1 / nA);
+      const meanB = ng.mulk(ng.sumAll(ng.mul(ker, MB)), 1 / nB);
+      ng.backward(ng.sub(meanB, meanA));
+      return [-P.g[0], -P.g[1]];
+    };
+
+    // static arrow field (one backward per arrow), computed once
+    const arrows = [];
+    for (let iy = 0; iy < GRID; iy++) for (let ix = 0; ix < GRID; ix++) {
+      const x = -DOM + (2 * DOM) * ix / (GRID - 1), y = -DOM + (2 * DOM) * iy / (GRID - 1);
+      const [fx, fy] = forceAt(x, y); const n = Math.hypot(fx, fy) + 1e-12;
+      arrows.push({ x, y, ux: fx / n, uy: fy / n, mag: n });
+    }
+    let mmax = 1e-9; for (const a of arrows) if (a.mag > mmax) mmax = a.mag;
+
+    api.state = { N, X, lab, Xd, MA, MB, nA, nB, forceAt, arrows, mmax, probe: [1.55, 1.5], trail: [] };
+
+    if (!api.canvas.dataset.flDrag) {
+      api.canvas.dataset.flDrag = '1';
+      const drop = (e) => {
+        const rc = api.canvas.getBoundingClientRect();
+        const Wd = api.size.W, Hd = api.size.H;
+        const side = Math.min(Wd - PAD * 2, Hd - PAD * 2 - 18);
+        const x0 = (Wd - side) / 2, y0 = PAD;
+        const wx = (-DOM) + ((e.clientX - rc.left - x0) / side) * 2 * DOM;
+        const wy = DOM - ((e.clientY - rc.top - y0) / side) * 2 * DOM;
+        if (Math.abs(wx) > DOM + 0.2 || Math.abs(wy) > DOM + 0.2) return;
+        api.state.probe = [wx, wy]; api.state.trail = []; api.render();
+      };
+      api.canvas.addEventListener('pointerdown', (e) => { api.canvas.setPointerCapture(e.pointerId); drop(e); });
+    }
+  },
+
+  onAction(name, api) {
+    if (name === 'drop') {
+      const ang = api.iter * 1.7, rad = 1.7;
+      api.state.probe = [Math.cos(ang) * rad, Math.sin(ang) * rad]; api.state.trail = [];
+    }
+  },
+
+  step(api) {
+    const st = api.state; if (!st) return;
+    const [px, py] = st.probe;
+    const [fx, fy] = st.forceAt(px, py); const n = Math.hypot(fx, fy) + 1e-12;
+    if (n > 1e-4) {
+      st.trail.push([px, py]); if (st.trail.length > 90) st.trail.shift();
+      st.probe = [px + 0.024 * fx / n, py + 0.024 * fy / n];
+    }
+  },
+
+  draw(api) {
+    const { ctx, colors, size, state: st } = api;
+    const Wd = size.W, Hd = size.H;
+    if (Wd === 0 || !st) return;
+    ctx.clearRect(0, 0, Wd, Hd);
+    const side = Math.min(Wd - PAD * 2, Hd - PAD * 2 - 18);
+    const x0 = (Wd - side) / 2, y0 = PAD;
+    const sx = (x) => x0 + ((x + DOM) / (2 * DOM)) * side;
+    const sy = (y) => y0 + ((DOM - y) / (2 * DOM)) * side;
+
+    ctx.fillStyle = colors.cellBg; ctx.fillRect(x0, y0, side, side);
+    ctx.strokeStyle = colors.border; ctx.lineWidth = 1; ctx.strokeRect(x0 + 0.5, y0 + 0.5, side - 1, side - 1);
+
+    // force field
+    for (const a of st.arrows) {
+      const len = (6 + 12 * Math.min(1, a.mag / st.mmax));
+      const cxp = sx(a.x), cyp = sy(a.y);
+      ctx.globalAlpha = 0.25 + 0.5 * Math.min(1, a.mag / st.mmax);
+      arrow(ctx, cxp - a.ux * len / 2, cyp + a.uy * len / 2, cxp + a.ux * len / 2, cyp - a.uy * len / 2, colors.muted, 1.2);
+    }
+    ctx.globalAlpha = 1;
+
+    // data points
+    for (let i = 0; i < st.N; i++) {
+      ctx.fillStyle = st.lab[i] ? colors.accent : colors.blue; ctx.globalAlpha = 0.7;
+      ctx.beginPath(); ctx.arc(sx(st.X[i * 2]), sy(st.X[i * 2 + 1]), 2.6, 0, Math.PI * 2); ctx.fill();
+    }
+    ctx.globalAlpha = 1;
+
+    // probe trail + probe
+    if (st.trail.length > 1) {
+      ctx.strokeStyle = colors.fg; ctx.globalAlpha = 0.5; ctx.lineWidth = 1.5; ctx.beginPath();
+      st.trail.forEach((p, i) => { const X = sx(p[0]), Y = sy(p[1]); i ? ctx.lineTo(X, Y) : ctx.moveTo(X, Y); });
+      ctx.stroke(); ctx.globalAlpha = 1;
+    }
+    const pp = st.probe;
+    ctx.fillStyle = colors.fg; ctx.beginPath(); ctx.arc(sx(pp[0]), sy(pp[1]), 6, 0, Math.PI * 2); ctx.fill();
+    ctx.lineWidth = 2; ctx.strokeStyle = colors.bg; ctx.stroke();
+
+    ctx.fillStyle = colors.muted; ctx.font = '11px ui-monospace, monospace';
+    ctx.textAlign = 'left'; ctx.textBaseline = 'bottom';
+    ctx.fillText('● prototype flows along −∇L · drag to drop it · blue = class it learns to detect', x0 + 2, Hd - 4);
+
+    api.readout('rd', `force everywhere → no dead zone · the prototype is pulled onto the data it should explain · nanograd`);
+  },
+});
+</script>

--- a/src/components/viz/KernelTrickLift.astro
+++ b/src/components/viz/KernelTrickLift.astro
@@ -1,0 +1,160 @@
+---
+interface Props {
+  caption?: string;
+  height?: number;
+}
+const { caption, height = 460 } = Astro.props;
+---
+<figure class="viz kerntrick" data-caption={caption} data-height={height} tabindex="0">
+  <div class="viz-cell"></div>
+</figure>
+
+<script>
+// The finite feature map, made spatial. The Yat numerator (w·x+b)² is a degree-2
+// polynomial kernel, and a degree-2 kernel has an EXACT, finite feature map
+// φ(x) = [x₁, x₂, x₁², x₂², x₁x₂, 1]. So a *flat* hyperplane in that 6-D space is
+// a curved boundary in input space — the kernel trick. We fit that flat separator
+// live on jax-js (np.linalg.solve in feature space), then lift the 2-D data into
+// 3-D by its quadratic score and let the plane slice it. Raise "lift": the data
+// rises off the floor and the single flat plane separates the classes. Look at
+// the floor: the same flat plane is a conic (a circle for rings, a hyperbola for
+// XOR). No infinite expansion, no activation — a finite kernel doing the work.
+import { defineViz } from './engine/vizkit.js';
+import { np, withJax, drawJaxLoading } from './engine/jax.js';
+import { rng32 } from './engine/datasets.js';
+
+const N = 170, F = 6, R3 = 1.0;
+const phi = (x1, x2) => [x1, x2, x1 * x1, x2 * x2, x1 * x2, 1];
+
+function makeData(kind, seed) {
+  const r = rng32(seed);
+  const randn = () => { let u = 0, v = 0; while (!u) u = r(); while (!v) v = r(); return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v); };
+  const X = new Float64Array(N * 2); const lab = new Int8Array(N);
+  for (let i = 0; i < N; i++) {
+    let x, y, c; const u = r();
+    if (kind === 'rings') { c = u < 0.5 ? 0 : 1; const a = 2 * Math.PI * r(); const rad = (c ? 1.25 : 0.55) + randn() * 0.07; x = rad * Math.cos(a); y = rad * Math.sin(a); }
+    else if (kind === 'xor') { const qx = r() < 0.5 ? -1 : 1, qy = r() < 0.5 ? -1 : 1; c = (qx * qy > 0) ? 1 : 0; x = qx * 0.85 + randn() * 0.18; y = qy * 0.85 + randn() * 0.18; }
+    else if (kind === 'spiral') { c = u < 0.5 ? 0 : 1; const a = r(); const ang = a * 3.3 + c * Math.PI; const rad = 0.2 + a * 1.1; x = rad * Math.cos(ang) + randn() * 0.05; y = rad * Math.sin(ang) + randn() * 0.05; }
+    else { c = u < 0.5 ? 0 : 1; x = (c ? 1 : -1) * 0.85 + randn() * 0.4; y = randn() * 0.6; }
+    X[i * 2] = x; X[i * 2 + 1] = y; lab[i] = c;
+  }
+  return { X, lab };
+}
+
+defineViz('kerntrick', {
+  title: 'The kernel trick: a flat plane in the finite feature map',
+  height: 460, stepsPerFrame: 1, autoplay: true,
+  controls: [
+    { type: 'play' },
+    { type: 'select', name: 'data', label: 'data', value: 'rings', reset: true,
+      options: [{ value: 'rings', label: 'rings' }, { value: 'xor', label: 'XOR' }, { value: 'blobs', label: 'blobs' }, { value: 'spiral', label: 'spiral' }] },
+    { type: 'range', name: 'lift', label: 'lift', min: 0, max: 1, step: 0.02, value: 1, reset: false, fmt: (v) => v.toFixed(2) },
+    { type: 'toggle', name: 'plane', label: 'separating plane', value: true },
+    { type: 'readout', name: 'rd' },
+  ],
+
+  setup(api) {
+    const kind = api.get('data');
+    const { X, lab } = makeData(kind, 5);
+    api.state = { kind, X, lab, spin: 0.7, v: null, Q: null, L: null, sc: 1, acc: 0, jaxReady: false };
+    withJax(api, () => {
+      // fit the flat separator in feature space:  (ΦᵀΦ + λI) v = Φᵀ y, solved on jax-js
+      const A = new Float64Array(F * F), b = new Float64Array(F);
+      for (let i = 0; i < N; i++) {
+        const p = phi(X[i * 2], X[i * 2 + 1]); const y = lab[i] ? 1 : -1;
+        for (let a = 0; a < F; a++) { b[a] += p[a] * y; for (let c = 0; c < F; c++) A[a * F + c] += p[a] * p[c]; }
+      }
+      for (let a = 0; a < F; a++) A[a * F + a] += 1e-3;
+      const sol = np.linalg.solve(np.reshape(np.array(A), [F, F]), np.reshape(np.array(b), [F, 1])).js();
+      const v = Array.from({ length: F }, (_, k) => (Array.isArray(sol[k]) ? sol[k][0] : sol[k]));
+      // per-point quadratic lift Q and (negated) linear plane height L; score s = Q + L
+      const Q = new Float64Array(N), L = new Float64Array(N); let mq = 1e-9, ok = 0;
+      for (let i = 0; i < N; i++) {
+        const x1 = X[i * 2], x2 = X[i * 2 + 1];
+        const q = v[2] * x1 * x1 + v[3] * x2 * x2 + v[4] * x1 * x2;
+        const l = v[0] * x1 + v[1] * x2 + v[5];
+        Q[i] = q; L[i] = l;
+        if (Math.abs(q) > mq) mq = Math.abs(q); if (Math.abs(l) > mq) mq = Math.abs(l);
+        if (((q + l) > 0 ? 1 : -1) === (lab[i] ? 1 : -1)) ok++;
+      }
+      api.state.v = v; api.state.Q = Q; api.state.L = L; api.state.sc = R3 / mq; api.state.acc = ok / N;
+    });
+  },
+
+  step(api) { if (api.state) api.state.spin += 0.012; },
+
+  draw(api) {
+    const { ctx, colors, size, state: st } = api;
+    const Wd = size.W, Hd = size.H;
+    if (Wd === 0 || !st) return;
+    ctx.clearRect(0, 0, Wd, Hd);
+    if (!st.jaxReady || !st.v) return drawJaxLoading(api);
+
+    const t = api.get('lift');
+    const v = st.v, sc = st.sc;
+    const cx = Wd / 2, cy = Hd / 2 + 14, S = Math.min(Wd, Hd) * 0.30;
+    const a = 0.62, b = st.spin;                       // tilt, spin
+    const ca = Math.cos(a), sa = Math.sin(a), cb = Math.cos(b), sb = Math.sin(b);
+    const rot = (p) => { const x1 = p[0] * cb + p[2] * sb, z1 = -p[0] * sb + p[2] * cb, y1 = p[1]; const y2 = y1 * ca - z1 * sa, z2 = y1 * sa + z1 * ca; return [x1, y2, z2]; };
+    const proj = (X3, Y3, Z3) => { const q = rot([X3, Y3, Z3]); return { x: cx + S * q[0], y: cy - S * q[1], d: q[2] }; };
+    const DS = 1.6;                                     // domain scale (data → world)
+
+    // ── floor (z=0) frame + the conic boundary s(x)=0 ──
+    const corners = [[-1, -1], [1, -1], [1, 1], [-1, 1]];
+    ctx.strokeStyle = colors.border; ctx.lineWidth = 1; ctx.globalAlpha = 0.7;
+    ctx.beginPath();
+    corners.forEach((c, i) => { const p = proj(c[0] * DS, c[1] * DS, 0); i ? ctx.lineTo(p.x, p.y) : ctx.moveTo(p.x, p.y); });
+    ctx.closePath(); ctx.stroke(); ctx.globalAlpha = 1;
+    // conic: sample grid, dot where |s| small (drawn on the floor)
+    const G = 46;
+    ctx.fillStyle = colors.fg;
+    for (let iy = 0; iy < G; iy++) for (let ix = 0; ix < G; ix++) {
+      const x1 = (-1 + 2 * ix / (G - 1)) * 1.55, x2 = (-1 + 2 * iy / (G - 1)) * 1.55;
+      const s = v[0] * x1 + v[1] * x2 + v[5] + v[2] * x1 * x1 + v[3] * x2 * x2 + v[4] * x1 * x2;
+      if (Math.abs(s) < 0.05) { const p = proj(x1 / 1.55 * DS, x2 / 1.55 * DS, 0); ctx.globalAlpha = 0.5; ctx.fillRect(p.x - 1, p.y - 1, 2, 2); }
+    }
+    ctx.globalAlpha = 1;
+
+    // ── separating plane z = −t·L(x)·sc  (flat, tilted) ──
+    const showPlane = api.get('plane') && t > 0.02;
+    const planeZ = (x1, x2) => -t * (v[0] * x1 + v[1] * x2 + v[5]) * sc;
+    let planeDepth = -2;
+    if (showPlane) {
+      const pc = corners.map((c) => { const x1 = c[0] * 1.55, x2 = c[1] * 1.55; return proj(c[0] * DS, c[1] * DS, planeZ(x1, x2)); });
+      planeDepth = (pc[0].d + pc[1].d + pc[2].d + pc[3].d) / 4;
+      ctx.beginPath(); pc.forEach((p, i) => i ? ctx.lineTo(p.x, p.y) : ctx.moveTo(p.x, p.y)); ctx.closePath();
+      ctx.fillStyle = colors.muted; ctx.globalAlpha = 0.16; ctx.fill();
+      ctx.globalAlpha = 0.5; ctx.strokeStyle = colors.muted; ctx.lineWidth = 1; ctx.stroke(); ctx.globalAlpha = 1;
+    }
+
+    // ── lifted points, depth-sorted ──
+    const pts = [];
+    for (let i = 0; i < N; i++) {
+      const x1 = st.X[i * 2], x2 = st.X[i * 2 + 1];
+      const z = t * st.Q[i] * sc;
+      const p = proj((x1 / 1.55) * DS, (x2 / 1.55) * DS, z);
+      pts.push({ x: p.x, y: p.y, d: p.d, c: st.lab[i], z });
+    }
+    pts.sort((u, w) => u.d - w.d);
+    for (const pt of pts) {
+      const col = pt.c ? colors.accent : colors.blue;
+      const shade = 0.55 + 0.45 * ((pt.d + 1) / 2);
+      ctx.globalAlpha = shade;
+      ctx.fillStyle = col;
+      ctx.beginPath(); ctx.arc(pt.x, pt.y, 3.1, 0, Math.PI * 2); ctx.fill();
+    }
+    ctx.globalAlpha = 1;
+
+    // labels
+    ctx.fillStyle = colors.muted; ctx.font = '11px ui-sans-serif, system-ui';
+    ctx.textAlign = 'left'; ctx.textBaseline = 'top';
+    ctx.fillText(t < 0.06 ? 'flat: one straight line cannot separate these classes' : 'lifted by the degree-2 feature map — a flat plane separates them', 10, 8);
+    ctx.textBaseline = 'bottom';
+    ctx.fillStyle = colors.faint; ctx.font = '10px ui-monospace, monospace';
+    ctx.fillText('floor: the flat plane is a conic boundary', 10, Hd - 6);
+
+    const conic = st.kind === 'rings' ? 'a circle' : st.kind === 'xor' ? 'a hyperbola' : 'a conic';
+    api.readout('rd', `flat separator in the 6-D feature map: ${(st.acc * 100).toFixed(1)}% · upstairs a plane, downstairs ${conic} · solved on jax-js`);
+  },
+});
+</script>

--- a/src/components/viz/LazyKernelRetrieval.astro
+++ b/src/components/viz/LazyKernelRetrieval.astro
@@ -1,0 +1,190 @@
+---
+interface Props {
+  caption?: string;
+  height?: number;
+}
+const { caption, height = 420 } = Astro.props;
+---
+<figure class="viz lazykernel" data-caption={caption} data-height={height} tabindex="0">
+  <div class="viz-cell"></div>
+</figure>
+
+<script>
+// Lazy loading, computed live on jax-js. A hidden layer of Yat-kernel units, one
+// prototype each, scattered across input space. Drag the query: only the few
+// prototypes NEAR it light up; the rest stay dormant. The activations are sparse
+// by the geometry of the kernel, so a layer can fetch just the active prototypes
+// (nearest-neighbour retrieval) instead of evaluating all of them. A ReLU layer
+// cannot — every ReLU unit is active on half of all inputs. All kernel values are
+// computed on the jax-js engine.
+import { defineViz } from './engine/vizkit.js';
+import { np, withJax, drawJaxLoading } from './engine/jax.js';
+import { parseColor } from './engine/draw.js';
+import { rng32 } from './engine/datasets.js';
+
+const B = 0.5;            // numerator bias b (≥ 0)
+const PAD = 10;
+const HM = 44;            // background field resolution
+const DOM = 2.4;          // domain half-width
+const ACTIVE_FRAC = 0.18; // active if activation ≥ this × max activation
+
+// kernel field of ONE prototype over a flat (M,2) grid — vectorised on jax-js
+const protoField = (gridFlat, wx, wy, eps) => {
+  const M = gridFlat.length / 2;
+  const Gv = np.reshape(np.array(gridFlat), [M, 2]);
+  const wv = np.reshape(np.array([wx, wy]), [1, 2]);
+  const dot = np.sum(Gv.ref.mul(wv.ref), 1);
+  const diff = np.subtract(Gv, wv);
+  const dist2 = np.sum(diff.ref.mul(diff), 1);
+  const lin = dot.add(B);
+  const num = lin.ref.mul(lin);
+  return num.div(dist2.add(eps)).js();
+};
+
+// activations of every prototype against one query — on jax-js
+const queryAct = (protos, K, qx, qy, eps) => {
+  const Pv = np.reshape(np.array(protos), [K, 2]);
+  const qv = np.reshape(np.array([qx, qy]), [1, 2]);
+  const dot = np.sum(Pv.ref.mul(qv.ref), 1);
+  const diff = np.subtract(Pv, qv);
+  const dist2 = np.sum(diff.ref.mul(diff), 1);
+  const lin = dot.add(B);
+  const num = lin.ref.mul(lin);
+  return num.div(dist2.add(eps)).js();
+};
+
+defineViz('lazykernel', {
+  title: 'Lazy loading: only the nearby prototypes fire',
+  height: 420,
+  controls: [
+    { type: 'range', name: 'K', label: 'prototypes', min: 6, max: 28, step: 1, value: 18, int: true, reset: true, fmt: (v) => v },
+    { type: 'range', name: 'eps', label: 'ε bandwidth', min: -1.4, max: 0.6, step: 0.05, value: -0.45, reset: false, fmt: (v) => Math.pow(10, v).toFixed(2) },
+    { type: 'readout', name: 'rd' },
+  ],
+
+  setup(api) {
+    const K = api.get('K');
+    const r = rng32(13);
+    // prototypes on a jittered grid for even coverage
+    const protos = new Float64Array(K * 2);
+    const cols = Math.ceil(Math.sqrt(K));
+    for (let k = 0; k < K; k++) {
+      const gx = (k % cols), gy = Math.floor(k / cols);
+      const jitter = 0.55;
+      protos[k * 2] = -DOM * 0.82 + (gx + 0.5) / cols * DOM * 1.64 + (r() - 0.5) * jitter;
+      protos[k * 2 + 1] = -DOM * 0.82 + (gy + 0.5) / cols * DOM * 1.64 + (r() - 0.5) * jitter;
+    }
+    // world grid for the background field
+    const gridFlat = new Float64Array(HM * HM * 2);
+    for (let py = 0; py < HM; py++) for (let px = 0; px < HM; px++) {
+      const i = py * HM + px;
+      gridFlat[i * 2] = -DOM + (px / (HM - 1)) * 2 * DOM;
+      gridFlat[i * 2 + 1] = DOM - (py / (HM - 1)) * 2 * DOM;
+    }
+    api.state = { K, protos, gridFlat, qx: 0.2, qy: 0.1, field: null, fieldEps: null, jaxReady: false };
+
+    // pointer drag moves the query
+    if (!api.canvas.dataset.lkDrag) {
+      api.canvas.dataset.lkDrag = '1';
+      const toWorld = (e) => {
+        const rc = api.canvas.getBoundingClientRect();
+        const W = api.size.W, H = api.size.H, footerH = 22;
+        const x0 = PAD, y0 = PAD, plotW = W - PAD * 2, plotH = H - PAD * 2 - footerH;
+        const px = (e.clientX - rc.left - x0) / plotW, py = (e.clientY - rc.top - y0) / plotH;
+        api.state.qx = Math.max(-DOM, Math.min(DOM, -DOM + px * 2 * DOM));
+        api.state.qy = Math.max(-DOM, Math.min(DOM, DOM - py * 2 * DOM));
+        api.render();
+      };
+      let drag = false;
+      api.canvas.addEventListener('pointerdown', (e) => { drag = true; api.canvas.setPointerCapture(e.pointerId); toWorld(e); });
+      api.canvas.addEventListener('pointermove', (e) => { if (drag) toWorld(e); });
+      api.canvas.addEventListener('pointerup', (e) => { drag = false; try { api.canvas.releasePointerCapture(e.pointerId); } catch {} });
+    }
+    withJax(api);
+  },
+
+  draw(api) {
+    const { ctx, colors, size, state: st } = api;
+    const W = size.W, H = size.H;
+    if (W === 0 || !st) return;
+    ctx.clearRect(0, 0, W, H);
+    if (!st.jaxReady) return drawJaxLoading(api);
+
+    const eps = Math.pow(10, api.get('eps'));
+    const footerH = 22;
+    const x0 = PAD, y0 = PAD, plotW = W - PAD * 2, plotH = H - PAD * 2 - footerH;
+    const sx = (x) => x0 + ((x + DOM) / (2 * DOM)) * plotW;
+    const sy = (y) => y0 + ((DOM - y) / (2 * DOM)) * plotH;
+
+    // ── background: max-kernel field, computed on jax-js (cached by eps) ──
+    if (!st.field || st.fieldEps !== eps) {
+      const M = HM * HM;
+      const fld = new Float64Array(M);
+      for (let k = 0; k < st.K; k++) {
+        const f = protoField(st.gridFlat, st.protos[k * 2], st.protos[k * 2 + 1], eps);
+        for (let i = 0; i < M; i++) if (f[i] > fld[i]) fld[i] = f[i];
+      }
+      st.field = fld; st.fieldEps = eps;
+    }
+    let fmax = 1e-9; for (let i = 0; i < st.field.length; i++) if (st.field[i] > fmax) fmax = st.field[i];
+    const bg = parseColor(colors.bg), accent = parseColor(colors.accent);
+    const img = ctx.createImageData(HM, HM);
+    for (let i = 0; i < HM * HM; i++) {
+      const t = Math.pow(Math.min(1, st.field[i] / fmax), 0.6) * 0.5;
+      img.data[i * 4] = Math.round(bg[0] + (accent[0] - bg[0]) * t);
+      img.data[i * 4 + 1] = Math.round(bg[1] + (accent[1] - bg[1]) * t);
+      img.data[i * 4 + 2] = Math.round(bg[2] + (accent[2] - bg[2]) * t);
+      img.data[i * 4 + 3] = 255;
+    }
+    const tmp = document.createElement('canvas'); tmp.width = HM; tmp.height = HM;
+    tmp.getContext('2d').putImageData(img, 0, 0);
+    ctx.imageSmoothingEnabled = true;
+    ctx.drawImage(tmp, x0, y0, plotW, plotH);
+    ctx.strokeStyle = colors.border; ctx.lineWidth = 1; ctx.strokeRect(x0 + 0.5, y0 + 0.5, plotW - 1, plotH - 1);
+
+    // ── query activations, on jax-js ──
+    const act = queryAct(st.protos, st.K, st.qx, st.qy, eps);
+    let amax = 1e-9; for (let k = 0; k < st.K; k++) if (act[k] > amax) amax = act[k];
+    const thresh = ACTIVE_FRAC * amax;
+    let nActive = 0;
+
+    const qpx = sx(st.qx), qpy = sy(st.qy);
+
+    // lines from the query to the active (retrieved) prototypes
+    for (let k = 0; k < st.K; k++) {
+      if (act[k] < thresh) continue;
+      ctx.strokeStyle = colors.accent; ctx.globalAlpha = 0.25 + 0.5 * (act[k] / amax); ctx.lineWidth = 1;
+      ctx.beginPath(); ctx.moveTo(qpx, qpy); ctx.lineTo(sx(st.protos[k * 2]), sy(st.protos[k * 2 + 1])); ctx.stroke();
+    }
+    ctx.globalAlpha = 1;
+
+    // prototypes: bright + ringed if active, faint if dormant
+    for (let k = 0; k < st.K; k++) {
+      const px = sx(st.protos[k * 2]), py = sy(st.protos[k * 2 + 1]);
+      const on = act[k] >= thresh;
+      if (on) nActive++;
+      const ratio = act[k] / amax;
+      if (on) {
+        ctx.fillStyle = colors.accent; ctx.globalAlpha = 0.55 + 0.45 * ratio;
+        ctx.beginPath(); ctx.arc(px, py, 4 + 6 * ratio, 0, Math.PI * 2); ctx.fill();
+        ctx.globalAlpha = 1; ctx.lineWidth = 1.6; ctx.strokeStyle = colors.bg; ctx.stroke();
+      } else {
+        ctx.fillStyle = colors.faint; ctx.globalAlpha = 0.6;
+        ctx.beginPath(); ctx.arc(px, py, 3, 0, Math.PI * 2); ctx.fill(); ctx.globalAlpha = 1;
+      }
+    }
+
+    // query marker
+    ctx.fillStyle = colors.fg;
+    ctx.beginPath(); ctx.arc(qpx, qpy, 5, 0, Math.PI * 2); ctx.fill();
+    ctx.lineWidth = 2; ctx.strokeStyle = colors.bg; ctx.stroke();
+
+    ctx.fillStyle = colors.muted; ctx.font = '11px ui-monospace, monospace';
+    ctx.textAlign = 'left'; ctx.textBaseline = 'bottom';
+    ctx.fillText('drag the ● query · lit prototypes are the ones a layer would fetch', x0, H - 5);
+
+    const pct = ((nActive / st.K) * 100).toFixed(0);
+    api.readout('rd', `active: ${nActive} / ${st.K} prototypes (${pct}%) · a ReLU layer would fire ~50% · jax-js`);
+  },
+});
+</script>

--- a/src/components/viz/YatAttribution.astro
+++ b/src/components/viz/YatAttribution.astro
@@ -1,0 +1,152 @@
+---
+interface Props {
+  caption?: string;
+  height?: number;
+}
+const { caption, height = 400 } = Astro.props;
+---
+<figure class="viz yatattrib" data-caption={caption} data-height={height} tabindex="0">
+  <div class="viz-cell"></div>
+</figure>
+
+<script>
+// Explainability is the kernel theory, computed live on jax-js. A layer of Yat
+// units, each a prototype with a message mᵤ. For a query x the output is an exact
+// convex combination of those messages, f(x) = Σ aᵤ mᵤ with aᵤ = κ(x,Wᵤ)/Σκ — the
+// representer theorem, no surrogate. Drag the query: the bars are the exact
+// contribution of each prototype to the output, and they always sum to one. The
+// readout also shows the query's RKHS intensity (‖x‖²+b)²/ε, a capacity you can
+// compute rather than guess.
+import { defineViz } from './engine/vizkit.js';
+import { np, withJax, drawJaxLoading } from './engine/jax.js';
+import { rng32 } from './engine/datasets.js';
+
+const B = 0.5;
+const PAD = 10;
+const DOM = 2.2;
+
+// kernel value of every prototype against the query — on jax-js
+const queryKer = (protos, K, qx, qy, eps) => {
+  const Pv = np.reshape(np.array(protos), [K, 2]);
+  const qv = np.reshape(np.array([qx, qy]), [1, 2]);
+  const dot = np.sum(Pv.ref.mul(qv.ref), 1);
+  const diff = np.subtract(Pv, qv);
+  const dist2 = np.sum(diff.ref.mul(diff), 1);
+  const lin = dot.add(B);
+  const num = lin.ref.mul(lin);
+  return num.div(dist2.add(eps)).js();
+};
+
+defineViz('yatattrib', {
+  title: 'Reading the output: exact attribution over prototypes',
+  height: 400,
+  controls: [
+    { type: 'range', name: 'K', label: 'prototypes', min: 5, max: 14, step: 1, value: 9, int: true, reset: true, fmt: (v) => v },
+    { type: 'range', name: 'eps', label: 'ε bandwidth', min: -1.2, max: 0.8, step: 0.05, value: -0.3, reset: false, fmt: (v) => Math.pow(10, v).toFixed(2) },
+    { type: 'readout', name: 'rd' },
+  ],
+
+  setup(api) {
+    const K = api.get('K');
+    const r = rng32(23);
+    const protos = new Float64Array(K * 2), msg = new Float64Array(K);
+    for (let k = 0; k < K; k++) {
+      protos[k * 2] = (r() * 2 - 1) * DOM * 0.82;
+      protos[k * 2 + 1] = (r() * 2 - 1) * DOM * 0.82;
+      msg[k] = r() < 0.5 ? -1 : 1;                  // each prototype's message (a class)
+    }
+    api.state = { K, protos, msg, qx: 0.3, qy: 0.2, jaxReady: false };
+
+    if (!api.canvas.dataset.atDrag) {
+      api.canvas.dataset.atDrag = '1';
+      const toWorld = (e) => {
+        const rc = api.canvas.getBoundingClientRect();
+        const Wd = api.size.W, Hd = api.size.H;
+        const side = Math.min(Hd - PAD * 2 - 20, Wd * 0.52);
+        const x0 = PAD, y0 = PAD;
+        const px = (e.clientX - rc.left - x0) / side, py = (e.clientY - rc.top - y0) / side;
+        if (px < -0.1 || px > 1.1) return;
+        api.state.qx = Math.max(-DOM, Math.min(DOM, -DOM + px * 2 * DOM));
+        api.state.qy = Math.max(-DOM, Math.min(DOM, DOM - py * 2 * DOM));
+        api.render();
+      };
+      let drag = false;
+      api.canvas.addEventListener('pointerdown', (e) => { drag = true; api.canvas.setPointerCapture(e.pointerId); toWorld(e); });
+      api.canvas.addEventListener('pointermove', (e) => { if (drag) toWorld(e); });
+      api.canvas.addEventListener('pointerup', (e) => { drag = false; try { api.canvas.releasePointerCapture(e.pointerId); } catch {} });
+    }
+    withJax(api);
+  },
+
+  draw(api) {
+    const { ctx, colors, size, state: st } = api;
+    const Wd = size.W, Hd = size.H;
+    if (Wd === 0 || !st) return;
+    ctx.clearRect(0, 0, Wd, Hd);
+    if (!st.jaxReady) return drawJaxLoading(api);
+
+    const eps = Math.pow(10, api.get('eps'));
+    const side = Math.min(Hd - PAD * 2 - 20, Wd * 0.52);
+    const x0 = PAD, y0 = PAD;
+    const sx = (x) => x0 + ((x + DOM) / (2 * DOM)) * side;
+    const sy = (y) => y0 + ((DOM - y) / (2 * DOM)) * side;
+
+    // attribution weights a_u = κ/Σκ  (κ on jax-js)
+    const ker = queryKer(st.protos, st.K, st.qx, st.qy, eps);
+    let Z = 0; for (let k = 0; k < st.K; k++) Z += ker[k];
+    Z = Z || 1e-9;
+    const a = new Float64Array(st.K);
+    let out = 0; for (let k = 0; k < st.K; k++) { a[k] = ker[k] / Z; out += a[k] * st.msg[k]; }
+    let amax = 1e-9; for (let k = 0; k < st.K; k++) if (a[k] > amax) amax = a[k];
+    const cap = Math.pow(st.qx * st.qx + st.qy * st.qy + B, 2) / eps;
+
+    const colFor = (m) => (m >= 0 ? colors.accent : colors.blue);
+
+    // ── left: prototype scatter ──
+    ctx.fillStyle = colors.cellBg; ctx.fillRect(x0, y0, side, side);
+    ctx.strokeStyle = colors.border; ctx.lineWidth = 1; ctx.strokeRect(x0 + 0.5, y0 + 0.5, side - 1, side - 1);
+    const qpx = sx(st.qx), qpy = sy(st.qy);
+    for (let k = 0; k < st.K; k++) {
+      const ratio = a[k] / amax;
+      ctx.strokeStyle = colFor(st.msg[k]); ctx.globalAlpha = 0.15 + 0.55 * ratio; ctx.lineWidth = 1 + 2 * ratio;
+      ctx.beginPath(); ctx.moveTo(qpx, qpy); ctx.lineTo(sx(st.protos[k * 2]), sy(st.protos[k * 2 + 1])); ctx.stroke();
+    }
+    ctx.globalAlpha = 1;
+    for (let k = 0; k < st.K; k++) {
+      const px = sx(st.protos[k * 2]), py = sy(st.protos[k * 2 + 1]);
+      const ratio = a[k] / amax;
+      ctx.fillStyle = colFor(st.msg[k]); ctx.globalAlpha = 0.45 + 0.5 * ratio;
+      ctx.beginPath(); ctx.arc(px, py, 4 + 7 * ratio, 0, Math.PI * 2); ctx.fill();
+      ctx.globalAlpha = 1; ctx.lineWidth = 1.4; ctx.strokeStyle = colors.bg; ctx.stroke();
+    }
+    ctx.fillStyle = colors.fg; ctx.beginPath(); ctx.arc(qpx, qpy, 5, 0, Math.PI * 2); ctx.fill();
+    ctx.lineWidth = 2; ctx.strokeStyle = colors.bg; ctx.stroke();
+    ctx.fillStyle = colors.muted; ctx.font = '10px ui-monospace, monospace';
+    ctx.textAlign = 'left'; ctx.textBaseline = 'bottom';
+    ctx.fillText('drag the ● query', x0 + 4, y0 + side - 4);
+
+    // ── right: contribution bars (sorted), each a_u ──
+    const bx = x0 + side + 16, bw = Wd - bx - PAD;
+    const order = Array.from({ length: st.K }, (_, k) => k).sort((p, q) => a[q] - a[p]);
+    const rowH = Math.min(26, (side - 24) / st.K);
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = colors.fg; ctx.font = '11px ui-sans-serif, system-ui'; ctx.textAlign = 'left';
+    ctx.fillText('contribution  aᵤ = κ(x,Wᵤ) / Σκ', bx, y0 + 8);
+    for (let i = 0; i < st.K; i++) {
+      const k = order[i];
+      const ry = y0 + 22 + i * rowH;
+      const full = bw - 54;
+      ctx.fillStyle = colors.cellBg; ctx.fillRect(bx + 44, ry, full, rowH - 5);
+      ctx.fillStyle = colFor(st.msg[k]); ctx.globalAlpha = 0.85;
+      ctx.fillRect(bx + 44, ry, full * (a[k] / Math.max(amax, 1e-9)), rowH - 5);
+      ctx.globalAlpha = 1;
+      ctx.fillStyle = colors.muted; ctx.font = '10px ui-monospace, monospace'; ctx.textAlign = 'left';
+      ctx.fillText(`W${k}${st.msg[k] >= 0 ? '+' : '−'}`, bx, ry + (rowH - 5) / 2);
+      ctx.fillStyle = colors.faint; ctx.textAlign = 'right';
+      ctx.fillText(a[k].toFixed(2), bx + 40, ry + (rowH - 5) / 2);
+    }
+
+    api.readout('rd', `output f(x) = Σ aᵤmᵤ = ${out.toFixed(2)} · Σ aᵤ = 1.00 (exact, no surrogate) · intensity ‖f‖² = ${cap.toFixed(1)} · jax-js`);
+  },
+});
+</script>

--- a/src/components/viz/YatExtrapolation.astro
+++ b/src/components/viz/YatExtrapolation.astro
@@ -1,0 +1,135 @@
+---
+interface Props {
+  caption?: string;
+  height?: number;
+}
+const { caption, height = 360 } = Astro.props;
+---
+<figure class="viz yatextrap" data-caption={caption} data-height={height} tabindex="0">
+  <div class="viz-cell"></div>
+</figure>
+
+<script>
+// Off-distribution behaviour, computed live on jax-js. One ReLU unit and one Yat
+// unit over a 1-D input. Inside the data band both are fine. Leave the band and
+// the ReLU pre-activation climbs without bound — a large, confident answer for an
+// input it has never seen — while the Yat unit stays bounded, its response a
+// fraction of its in-data peak. Unbounded extrapolation versus a bounded,
+// "nothing near here" response: the difference between a half-plane and a kernel.
+import { defineViz } from './engine/vizkit.js';
+import { np, withJax, drawJaxLoading } from './engine/jax.js';
+
+const XMIN = -6, XMAX = 6, M = 260;
+const W = 1.0, BIAS = 0.6, C = 0.0;       // weight, bias b, prototype centre
+const BAND = 2.0;                          // in-distribution band |x| ≤ BAND
+const PADL = 40, PADR = 14, PADT = 16, PADB = 40;
+
+defineViz('yatextrap', {
+  title: 'Off-distribution: unbounded ReLU vs bounded Yat',
+  height: 360,
+  controls: [
+    { type: 'range', name: 'eps', label: 'ε bandwidth', min: -1.2, max: 0.8, step: 0.05, value: -0.2, reset: false, fmt: (v) => Math.pow(10, v).toFixed(2) },
+    { type: 'readout', name: 'rd' },
+  ],
+
+  setup(api) {
+    api.state = { qx: 3.2 };
+    if (!api.canvas.dataset.exDrag) {
+      api.canvas.dataset.exDrag = '1';
+      const onP = (e) => {
+        const r = api.canvas.getBoundingClientRect();
+        const plotW = api.size.W - PADL - PADR;
+        const t = (e.clientX - r.left - PADL) / plotW;
+        api.state.qx = Math.max(XMIN, Math.min(XMAX, XMIN + t * (XMAX - XMIN)));
+        api.render();
+      };
+      let drag = false;
+      api.canvas.addEventListener('pointerdown', (e) => { drag = true; api.canvas.setPointerCapture(e.pointerId); onP(e); });
+      api.canvas.addEventListener('pointermove', (e) => { if (drag) onP(e); });
+      api.canvas.addEventListener('pointerup', (e) => { drag = false; try { api.canvas.releasePointerCapture(e.pointerId); } catch {} });
+    }
+    withJax(api);
+  },
+
+  draw(api) {
+    const { ctx, colors, size, state } = api;
+    const Wd = size.W, Hd = size.H;
+    if (Wd === 0) return;
+    if (!state.jaxReady) return drawJaxLoading(api);
+
+    const eps = Math.pow(10, api.get('eps'));
+    // compute curves on jax-js
+    const xg = new Float64Array(M);
+    for (let i = 0; i < M; i++) xg[i] = XMIN + (i / (M - 1)) * (XMAX - XMIN);
+    const X = np.array(xg);
+    const lin = X.ref.mul(W).add(BIAS);
+    const linJs = lin.ref.js();
+    const cen = X.add(-C);                         // x − c  (scalar form)
+    const dist2 = cen.ref.mul(cen);
+    const num = lin.ref.mul(lin);                 // (w·x+b)²   (lin consumed here)
+    const yat = num.div(dist2.add(eps)).js();
+    const relu = Float64Array.from(linJs, (v) => Math.max(v, 0));
+
+    const plotW = Wd - PADL - PADR, plotH = Hd - PADT - PADB;
+    const yMax = 5.0;                             // fixed cap so ReLU visibly exits the top
+    const sx = (x) => PADL + ((x - XMIN) / (XMAX - XMIN)) * plotW;
+    const sy = (y) => PADT + (1 - Math.min(y, yMax) / yMax) * plotH;
+
+    // in-distribution band
+    ctx.fillStyle = colors.faint; ctx.globalAlpha = 0.12;
+    ctx.fillRect(sx(-BAND), PADT, sx(BAND) - sx(-BAND), plotH);
+    ctx.globalAlpha = 1;
+    ctx.fillStyle = colors.faint; ctx.font = '10px ui-monospace, monospace';
+    ctx.textAlign = 'center'; ctx.textBaseline = 'top';
+    ctx.fillText('data band', sx(0), PADT + 2);
+
+    // axes
+    ctx.strokeStyle = colors.border; ctx.lineWidth = 1;
+    ctx.beginPath(); ctx.moveTo(PADL, sy(0)); ctx.lineTo(Wd - PADR, sy(0)); ctx.stroke();
+    ctx.fillStyle = colors.faint; ctx.textAlign = 'center'; ctx.textBaseline = 'top';
+    for (let gx = XMIN; gx <= XMAX; gx += 2) ctx.fillText(String(gx), sx(gx), Hd - PADB + 8);
+    ctx.save(); ctx.translate(12, PADT + plotH / 2); ctx.rotate(-Math.PI / 2);
+    ctx.textAlign = 'center'; ctx.textBaseline = 'middle'; ctx.fillText('response', 0, 0); ctx.restore();
+
+    const plot = (arr, color, lw) => {
+      ctx.strokeStyle = color; ctx.lineWidth = lw; ctx.beginPath();
+      let started = false;
+      for (let i = 0; i < M; i++) {
+        const px = sx(xg[i]), py = sy(arr[i]);
+        if (arr[i] > yMax * 1.02) { started = false; continue; }   // break where it exits top
+        started ? ctx.lineTo(px, py) : ctx.moveTo(px, py); started = true;
+      }
+      ctx.stroke();
+    };
+    plot(relu, colors.blue, 2);
+    plot(yat, colors.accent, 2);
+
+    // ReLU "→ ∞" marker where it leaves the top
+    let exitX = null;
+    for (let i = 0; i < M; i++) if (relu[i] > yMax) { exitX = xg[i]; break; }
+    if (exitX !== null) {
+      ctx.fillStyle = colors.blue; ctx.textAlign = 'left'; ctx.textBaseline = 'bottom';
+      ctx.font = '11px ui-sans-serif, system-ui';
+      ctx.fillText('ReLU → ∞ (unbounded)', sx(exitX) + 4, PADT + 14);
+    }
+
+    // legend
+    ctx.font = '11px ui-sans-serif, system-ui'; ctx.textBaseline = 'middle'; ctx.textAlign = 'left';
+    ctx.fillStyle = colors.blue; ctx.fillRect(Wd - PADR - 150, PADT + 6, 14, 3);
+    ctx.fillStyle = colors.fg; ctx.fillText('ReLU  σ(w·x+b)', Wd - PADR - 132, PADT + 8);
+    ctx.fillStyle = colors.accent; ctx.fillRect(Wd - PADR - 150, PADT + 22, 14, 3);
+    ctx.fillStyle = colors.fg; ctx.fillText('Yat unit', Wd - PADR - 132, PADT + 24);
+
+    // query
+    const qx = state.qx, qi = Math.round(((qx - XMIN) / (XMAX - XMIN)) * (M - 1));
+    const rq = relu[qi], yq = yat[qi];
+    ctx.strokeStyle = colors.fg; ctx.lineWidth = 1; ctx.setLineDash([3, 4]);
+    ctx.beginPath(); ctx.moveTo(sx(qx), PADT); ctx.lineTo(sx(qx), PADT + plotH); ctx.stroke(); ctx.setLineDash([]);
+    if (yq <= yMax) { ctx.fillStyle = colors.accent; ctx.beginPath(); ctx.arc(sx(qx), sy(yq), 4, 0, Math.PI * 2); ctx.fill(); }
+    if (rq <= yMax) { ctx.fillStyle = colors.blue; ctx.beginPath(); ctx.arc(sx(qx), sy(rq), 4, 0, Math.PI * 2); ctx.fill(); }
+
+    const inband = Math.abs(qx) <= BAND;
+    api.readout('rd', `x ${qx.toFixed(2)} ${inband ? '(in data)' : '(off-distribution)'} · ReLU ${rq.toFixed(2)} · Yat ${yq.toFixed(2)} · jax-js`);
+  },
+});
+</script>

--- a/src/components/viz/YatMlpLearning.astro
+++ b/src/components/viz/YatMlpLearning.astro
@@ -1,0 +1,186 @@
+---
+interface Props {
+  caption?: string;
+  height?: number;
+}
+const { caption, height = 440 } = Astro.props;
+---
+<figure class="viz yatmlplearn" data-caption={caption} data-height={height} tabindex="0">
+  <div class="viz-cell"></div>
+</figure>
+
+<script>
+// A Yat-kernel MLP trained live in your browser on the nanograd autodiff engine.
+// Each hidden unit is the Euclidean Yat kernel (W·x+b)²/(‖x−W‖²+ε) against a
+// learned prototype W; a linear readout turns the kernel activations into a
+// logit. There is no activation function. Watch the prototypes (the kernel
+// centres) migrate onto the data and the decision field form — the network is
+// in the rich, feature-learning regime, not the lazy/NTK regime, yet it is a
+// kernel machine at every step.
+import { defineViz } from './engine/vizkit.js';
+import { parseColor } from './engine/draw.js';
+import * as ng from './engine/nanograd.js';
+import { rng32 } from './engine/datasets.js';
+
+const B = 0.5;        // numerator bias b (≥ 0)
+const PAD = 10;
+const HM = 56;        // field resolution
+
+function makeData(kind, N, seed) {
+  const r = rng32(seed);
+  const randn = () => { let u = 0, v = 0; while (!u) u = r(); while (!v) v = r(); return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v); };
+  const X = new Float64Array(N * 2), lab = new Int8Array(N);
+  for (let i = 0; i < N; i++) {
+    let x, y, c; const u = r();
+    if (kind === 'moons') { c = u < 0.5 ? 0 : 1; const a = Math.PI * r();
+      if (c === 0) { x = Math.cos(a); y = Math.sin(a); } else { x = 1 - Math.cos(a); y = 0.5 - Math.sin(a); }
+      x += randn() * 0.08; y += randn() * 0.08; x -= 0.5; y -= 0.25; }
+    else if (kind === 'spiral') { c = u < 0.5 ? 0 : 1; const t = r(); const a = t * 3.3 + c * Math.PI; const rad = 0.2 + t * 1.05;
+      x = rad * Math.cos(a) + randn() * 0.05; y = rad * Math.sin(a) + randn() * 0.05; }
+    else if (kind === 'rings') { c = u < 0.5 ? 0 : 1; const a = 2 * Math.PI * r(); const rad = (c ? 1.25 : 0.5) + randn() * 0.08;
+      x = rad * Math.cos(a); y = rad * Math.sin(a); }
+    else { c = u < 0.5 ? 0 : 1; x = (c ? 1 : -1) * 0.85 + randn() * 0.5; y = randn() * 0.6; }
+    X[i * 2] = x; X[i * 2 + 1] = y; lab[i] = c;
+  }
+  return { X, lab, N };
+}
+
+defineViz('yatmlplearn', {
+  title: 'A Yat-kernel MLP learning, live',
+  height: 440, stepsPerFrame: 1.5, maxStep: 650, autoplay: true,
+  controls: [
+    { type: 'play' }, { type: 'step' }, { type: 'button', name: 'reroll', label: 're-roll', reset: true },
+    { type: 'speed', presets: [0.5, 1, 2, 4] },
+    { type: 'newrow' },
+    { type: 'select', name: 'data', label: 'data', value: 'moons', reset: true,
+      options: [{ value: 'moons', label: 'two-moons' }, { value: 'spiral', label: 'spiral' }, { value: 'rings', label: 'rings' }, { value: 'blobs', label: 'blobs' }] },
+    { type: 'range', name: 'K', label: 'prototypes', min: 4, max: 32, step: 2, value: 16, int: true, reset: true, fmt: (v) => v },
+    { type: 'range', name: 'eps', label: 'ε bandwidth', min: -1.4, max: 0.6, step: 0.05, value: -0.3, reset: false, fmt: (v) => Math.pow(10, v).toFixed(2) },
+    { type: 'readout', name: 'rd' },
+  ],
+
+  setup(api) {
+    const kind = api.get('data'), K = api.get('K'), N = 150;
+    const data = makeData(kind, N, 7);
+    let xmn = 1e9, xmx = -1e9, ymn = 1e9, ymx = -1e9;
+    for (let i = 0; i < N; i++) { const x = data.X[i * 2], y = data.X[i * 2 + 1];
+      xmn = Math.min(xmn, x); xmx = Math.max(xmx, x); ymn = Math.min(ymn, y); ymx = Math.max(ymx, y); }
+    const mx = (xmx - xmn) * 0.2 + 0.25, my = (ymx - ymn) * 0.2 + 0.25;
+    const bounds = { xmn: xmn - mx, xmx: xmx + mx, ymn: ymn - my, ymx: ymx + my };
+
+    const Xd = ng.tensor(N, 2, data.X);
+    const yArr = new Float64Array(N); for (let i = 0; i < N; i++) yArr[i] = data.lab[i] ? 1 : -1;
+    const Yneg = ng.tensor(N, 1, Float64Array.from(yArr, (v) => -v));
+
+    const r = rng32(101);
+    const W = ng.param(K, 2, (i) => (i % 2 === 0)
+      ? bounds.xmn + (bounds.xmx - bounds.xmn) * r()
+      : bounds.ymn + (bounds.ymx - bounds.ymn) * r());
+    const A = ng.param(K, 1, () => r() * 0.4 - 0.2);
+    const c = ng.param(1, 1, () => 0);
+    const adam = new ng.Adam([W, A, c], 0.03);
+
+    const epsOf = () => Math.pow(10, api.get('eps'));
+    const forward = () => {                                   // logits over the data batch
+      const eps = epsOf();
+      const dot = ng.matmul(Xd, ng.transpose(W));             // (N,K) = x·W
+      const xn = ng.sumRows(ng.square(Xd));                   // (N,1) = ‖x‖²
+      const wn = ng.transpose(ng.sumRows(ng.square(W)));      // (1,K) = ‖W‖²
+      const dist2 = ng.add(ng.add(xn, wn), ng.mulk(dot, -2)); // (N,K) = ‖x−W‖²
+      const num = ng.square(ng.addk(dot, B));                 // (N,K) = (x·W+b)²
+      const ker = ng.div(num, ng.addk(dist2, eps));           // (N,K) = Yat activations
+      return ng.add(ng.matmul(ker, A), c);                    // (N,1) logit
+    };
+
+    api.state = { N, K, data, bounds, Xd, Yneg, W, A, c, adam, forward, epsOf, loss: 0, acc: 0 };
+  },
+
+  step(api) {
+    const st = api.state;
+    const logit = st.forward();
+    const loss = ng.mulk(ng.sumAll(ng.softplus(ng.mul(logit, st.Yneg))), 1 / st.N);
+    ng.backward(loss);
+    st.adam.step();
+    st.loss = loss.d[0];
+    let ok = 0; for (let i = 0; i < st.N; i++) { const p = logit.d[i] > 0 ? 1 : 0; if (p === st.data.lab[i]) ok++; }
+    st.acc = ok / st.N;
+  },
+
+  draw(api) {
+    const { ctx, colors, size, state: st } = api;
+    const W = size.W, H = size.H;
+    if (W === 0 || !st) return;
+    ctx.clearRect(0, 0, W, H);
+
+    const footerH = 22;
+    const x0 = PAD, y0 = PAD, plotW = W - PAD * 2, plotH = H - PAD * 2 - footerH;
+    const { xmn, xmx, ymn, ymx } = st.bounds;
+    const sx = (x) => x0 + ((x - xmn) / (xmx - xmn)) * plotW;
+    const sy = (y) => y0 + ((ymx - y) / (ymx - ymn)) * plotH;
+    const wx = (px) => xmn + ((px - x0) / plotW) * (xmx - xmn);
+    const wy = (py) => ymx - ((py - y0) / plotH) * (ymx - ymn);
+
+    const eps = st.epsOf();
+    const predict = (px, py) => {
+      let logit = st.c.d[0];
+      for (let k = 0; k < st.K; k++) {
+        const wxk = st.W.d[k * 2], wyk = st.W.d[k * 2 + 1];
+        const d = px * wxk + py * wyk;
+        const di = (px - wxk) * (px - wxk) + (py - wyk) * (py - wyk);
+        logit += ((d + B) * (d + B) / (di + eps)) * st.A.d[k];
+      }
+      return logit;
+    };
+
+    // ── decision field (diverging heatmap: class 0 ↔ class 1) ──
+    const bg = parseColor(colors.bg);
+    const cls1 = parseColor(colors.accent);     // label 1
+    const cls0 = parseColor(colors.blue);       // label 0
+    const img = ctx.createImageData(HM, HM);
+    for (let py = 0; py < HM; py++) {
+      const yw = wy(y0 + (py / (HM - 1)) * plotH);
+      for (let px = 0; px < HM; px++) {
+        const xw = wx(x0 + (px / (HM - 1)) * plotW);
+        const v = predict(xw, yw);
+        const t = Math.min(1, Math.abs(Math.tanh(v * 0.9)));
+        const tgt = v >= 0 ? cls1 : cls0;
+        const o = (py * HM + px) * 4;
+        img.data[o] = Math.round(bg[0] + (tgt[0] - bg[0]) * t * 0.8);
+        img.data[o + 1] = Math.round(bg[1] + (tgt[1] - bg[1]) * t * 0.8);
+        img.data[o + 2] = Math.round(bg[2] + (tgt[2] - bg[2]) * t * 0.8);
+        img.data[o + 3] = 255;
+      }
+    }
+    const tmp = document.createElement('canvas'); tmp.width = HM; tmp.height = HM;
+    tmp.getContext('2d').putImageData(img, 0, 0);
+    ctx.imageSmoothingEnabled = true;
+    ctx.drawImage(tmp, x0, y0, plotW, plotH);
+    ctx.strokeStyle = colors.border; ctx.lineWidth = 1; ctx.strokeRect(x0 + 0.5, y0 + 0.5, plotW - 1, plotH - 1);
+
+    // ── data points ──
+    for (let i = 0; i < st.N; i++) {
+      const c = st.data.lab[i] ? colors.accent : colors.blue;
+      ctx.fillStyle = c; ctx.globalAlpha = 0.85;
+      ctx.beginPath(); ctx.arc(sx(st.data.X[i * 2]), sy(st.data.X[i * 2 + 1]), 2.6, 0, Math.PI * 2); ctx.fill();
+    }
+    ctx.globalAlpha = 1;
+
+    // ── prototypes (kernel centres), coloured by the class they vote for ──
+    for (let k = 0; k < st.K; k++) {
+      const px = sx(st.W.d[k * 2]), py = sy(st.W.d[k * 2 + 1]);
+      const a = st.A.d[k];
+      const c = a >= 0 ? colors.accent : colors.blue;
+      const rad = 3.5 + Math.min(6, Math.abs(a) * 6);
+      ctx.beginPath(); ctx.arc(px, py, rad, 0, Math.PI * 2);
+      ctx.fillStyle = c; ctx.globalAlpha = 0.9; ctx.fill();
+      ctx.globalAlpha = 1; ctx.lineWidth = 1.6; ctx.strokeStyle = colors.bg; ctx.stroke();
+    }
+
+    ctx.fillStyle = colors.muted; ctx.font = '11px ui-monospace, monospace';
+    ctx.textAlign = 'left'; ctx.textBaseline = 'bottom';
+    ctx.fillText('● data · ◯ prototype (kernel centre, sized by readout weight)', x0, H - 5);
+
+    api.readout('rd', `step ${api.iter} · loss ${st.loss.toFixed(3)} · train acc ${(st.acc * 100).toFixed(1)}% · ${st.K} prototypes · nanograd`);
+  },
+});
+</script>

--- a/src/content/blog/what-a-finite-kernel-buys-an-mlp.mdx
+++ b/src/content/blog/what-a-finite-kernel-buys-an-mlp.mdx
@@ -1,0 +1,178 @@
+---
+title: "What a Finite Kernel Buys an MLP"
+description: "Replace the activation function with a finite, explicit, positive-definite kernel — the Yat kernel — and an MLP stops being a stack of linear maps glued by a nonlinearity. It becomes a kernel machine, with locality, attribution, geometry, capacity control, and a feature map you can write down."
+seoDescription: "Replacing the activation in an MLP with the finite, positive-definite Yat kernel turns it into a kernel machine: locality, attribution, geometry, and capacity control."
+pubDate: 2026-06-18
+companion: yat-mlp-jax-flax-nnx
+tags: [ml, kernels, interpretability, mlp, rkhs, yat, geometry, deep-learning]
+references:
+  - authors: "Mercer, J."
+    year: 1909
+    title: "Functions of Positive and Negative Type, and their Connection with the Theory of Integral Equations"
+    venue: "Philosophical Transactions of the Royal Society A 209, 415–446"
+  - authors: "Kimeldorf, G., Wahba, G."
+    year: 1971
+    title: "Some Results on Tchebycheffian Spline Functions"
+    venue: "Journal of Mathematical Analysis and Applications 33(1), 82–95"
+  - authors: "Schölkopf, B., Herbrich, R., Smola, A. J."
+    year: 2001
+    title: "A Generalized Representer Theorem"
+    venue: "COLT 2001, 416–426"
+  - authors: "Rahimi, A., Recht, B."
+    year: 2007
+    title: "Random Features for Large-Scale Kernel Machines"
+    venue: "NeurIPS 2007"
+    url: "https://people.eecs.berkeley.edu/~brecht/papers/07.rah.rec.nips.pdf"
+  - authors: "Cho, Y., Saul, L. K."
+    year: 2009
+    title: "Kernel Methods for Deep Learning"
+    venue: "NeurIPS 2009"
+  - authors: "Jacot, A., Gabriel, F., Hongler, C."
+    year: 2018
+    title: "Neural Tangent Kernel: Convergence and Generalization in Neural Networks"
+    venue: "NeurIPS 2018"
+    arxiv: "1806.07572"
+  - authors: "Chizat, L., Oyallon, E., Bach, F."
+    year: 2019
+    title: "On Lazy Training in Differentiable Programming"
+    venue: "NeurIPS 2019"
+    arxiv: "1812.07956"
+  - authors: "Nadaraya, E. A."
+    year: 1964
+    title: "On Estimating Regression"
+    venue: "Theory of Probability & Its Applications 9(1), 141–142"
+  - authors: "Watson, G. S."
+    year: 1964
+    title: "Smooth Regression Analysis"
+    venue: "Sankhyā: The Indian Journal of Statistics, Series A 26(4), 359–372"
+  - authors: "Choromanski, K., et al."
+    year: 2021
+    title: "Rethinking Attention with Performers"
+    venue: "ICLR 2021"
+    arxiv: "2009.14794"
+  - authors: "Bouhsine, T."
+    year: 2026
+    title: "A Universal Reproducing Kernel Hilbert Space from Polynomial Alignment and IMQ Distance"
+    arxiv: "2605.03262"
+keywords:
+  - Yat kernel
+  - kernel MLP
+  - activation function replacement
+  - RKHS neural network
+  - Mercer kernel deep learning
+  - neural tangent kernel
+  - prototype neuron
+  - interpretable MLP
+  - inverse multiquadric kernel
+  - finite kernel
+  - representer theorem
+  - random features
+---
+
+import YatMlpLearning from '../../components/viz/YatMlpLearning.astro';
+import LazyKernelRetrieval from '../../components/viz/LazyKernelRetrieval.astro';
+import YatAttribution from '../../components/viz/YatAttribution.astro';
+import YatExtrapolation from '../../components/viz/YatExtrapolation.astro';
+import KernelTrickLift from '../../components/viz/KernelTrickLift.astro';
+import FeatureLearningFlow from '../../components/viz/FeatureLearningFlow.astro';
+
+Every multilayer perceptron is built from one primitive: a linear map followed by a pointwise nonlinearity, $h = \sigma(w^\top x + b)$. The activation $\sigma$ is the part nobody can quite justify. We reach for ReLU because it trains, GELU because it trains a little better, and we tell ourselves the choice is a detail. It is not a detail. A pointwise activation is a patch over a missing object, and the price of the patch is everything that makes an MLP opaque: no geometry, no centers, no attribution, no capacity you can name.
+
+This post asks a single question. What if the primitive were not a linear map plus an activation, but a **finite, explicit, positive-definite kernel** — a similarity between the input and a learned center — with no $\sigma$ at all? The nonlinearity, the locality, and the geometry would then come from the kernel, not from a function we bolt on afterward. The kernel I will use is the **Yat kernel**; the point is the list of things you get for free once the unit is a kernel. This is the catalogue.
+
+It builds directly on two earlier pieces: [what an MLP knows when its unit is a kernel](/blog/what-an-mlp-knows/), which constructs the unit, and [why activations are bad for geometry](/blog/activations-are-bad-for-geometry/), which is the problem this construction answers.
+
+## First, the kernel you do *not* mean
+
+There is already a fashionable way a kernel shows up in a neural network, and it is the wrong one for this story. Take a network, send its width to infinity, and in the lazy regime it linearizes around initialization into a fixed kernel — the **Neural Tangent Kernel** (Jacot et al., 2018). The NTK is real and useful, but look at what it is: *emergent* (you do not write it down, it falls out of a limit), *infinite-dimensional*, *fixed at initialization*, and *data-blind*. It describes a network that has, in a precise sense (Chizat et al., 2019), stopped learning features — the parameters barely move, and the function is a kernel regressor against a kernel nobody chose.
+
+That is the opposite of what I want. Here the kernel is **finite** (you write it down in closed form; its core has a feature map of finite dimension), **explicit** (a design choice, not an asymptotic accident), and **learnable** (its centers are parameters that move). The network is free to be in the rich, feature-learning regime — the prototypes migrate toward structure in the data — and it is *still* a kernel machine at every layer, because the kernel is the unit and not a description of the unit's limit. "Not the NTK" is the whole framing: do not wait for an infinite-width limit to hand you a kernel you cannot steer. Install one.
+
+## The unit
+
+For an input $x\in\mathbb{R}^d$ and a learned center $W_u\in\mathbb{R}^d$, with two non-negative scalars $b\ge 0$ and $\varepsilon>0$, hidden unit $u$ computes
+
+$$
+y_u(x) \;=\; \alpha_u\,\underbrace{\frac{(W_u^\top x + b)^2}{\lVert x - W_u\rVert^2 + \varepsilon}}_{k_{b,\varepsilon}(W_u,\,x)} .
+$$
+
+There is no $\sigma$. The numerator is a **squared alignment** (how much $x$ points along $W_u$); the denominator is an **inverse-multiquadric distance gate** (how close $x$ sits to $W_u$). The unit fires when the input is both aligned with and near its center, and its response is a single localized peak at $x = W_u$. A ReLU unit, by contrast, carries only a *direction* and fires across an entire half-space; the kernel unit carries a *point*. That difference — a center in input space versus a hyperplane — is the source of everything below, and it is developed at length in [what an MLP knows](/blog/what-an-mlp-knows/).
+
+Two properties make this a *kernel* and not just a clever activation. It is **non-negative** ($b\ge 0$ keeps the numerator a square, the denominator is positive). And it is **positive definite**: $k_{b,\varepsilon}$ is the Schur product of a degree-2 polynomial kernel $(W_u^\top x + b)^2$ — PSD and, crucially, *finite-rank* — with an inverse-multiquadric kernel $1/(\lVert x-W_u\rVert^2 + \varepsilon)$, which is PSD by Schoenberg. A product of PSD kernels is PSD, so $k_{b,\varepsilon}$ is a genuine Mercer kernel; Bouhsine (2026) proves it positive definite for $\varepsilon\ge 0$ and *universal* for $\varepsilon>0$. Non-negative and positive definite are independent properties, and the unit has both — the useful corner, as the [convex-readout companion](/blog/convex-readout-jax-flax-nnx/) shows in code. Everything that follows is a consequence of one of those two facts.
+
+Here is the whole thing learning, in your browser. A layer of these units — one prototype each, no activation function — trained by gradient descent on a 2-D task. Watch the prototypes (the kernel centres) migrate onto the data and the decision field form. The parameters move freely: this is the *rich, feature-learning regime*, the opposite of the NTK's frozen kernel, and yet every step is an exact kernel machine.
+
+<YatMlpLearning caption="A Yat-kernel MLP trained live on the nanograd autodiff engine. Each hidden unit is the Yat kernel against a learned prototype; a linear layer reads the kernel activations into a decision field. There is no activation function. The prototypes (rings, sized by their readout weight and coloured by the class they vote for) start scattered and migrate onto the data — feature learning, not the lazy/NTK regime. Try the spiral and the rings, and move the ε bandwidth." />
+
+The rest of this post is the catalogue of what that move buys you.
+
+## Feature 1 — Lazy loading: the layer evaluates only what is near
+
+Because the response is sharply peaked at the center, the units that matter for a given input are the ones whose centers are *near it*. On normalized inputs the Yat unit reduces to $k^\circ(S) = (S+b)^2/(\varepsilon + 2 - 2S)$ in the cosine similarity $S=\langle x, W_u\rangle$ — a clean bump that is maximal at $S=1$ and falls off as the input rotates away. A ReLU layer cannot do this: a ReLU unit is active on half of all inputs, so there is no neighborhood to exploit and every unit must be evaluated for every input.
+
+A localized kernel turns dense matrix multiplication into a **retrieval problem**. The hidden activations are sparse by construction: for any $x$, only the prototypes in its neighborhood contribute meaningfully, so you can index the centers and fetch the few that are close — nearest-neighbor or approximate-NN over $\{W_u\}$ — instead of touching the whole layer. This is conditional computation that falls out of the *geometry* of the unit rather than a learned gating network bolted on top, the way a mixture-of-experts router is. It is also why the prototype set is a **growable memory**: adding a center adds capacity locally, like adding a support vector, and you can load centers on demand rather than holding a fixed dense bank. The activation function gave you none of this; a half-space has no "near."
+
+<LazyKernelRetrieval caption="Lazy loading, computed live on jax-js. A hidden layer of Yat-kernel units scattered across input space. Drag the query: only the handful of prototypes near it light up (and connect) — those are the ones a layer would actually fetch. The readout reports the active fraction, typically a small slice of the layer. A ReLU layer cannot do this: every ReLU unit is active on half of all inputs. Lower ε to tighten the kernels and watch the active set shrink." />
+
+## Feature 2 — Explainability is not bolted on, it is the kernel theory
+
+The reason kernel methods were interpretable long before "interpretability" was a field is that a Mercer kernel comes with a reproducing kernel Hilbert space, and an RKHS hands you four things you otherwise have to reverse-engineer. The same argument I made for attention in [attention is explainable because it is a kernel](/blog/attention-is-a-kernel/) applies verbatim to the MLP unit, because both are now the same object.
+
+- **A named center.** Each unit's output is a similarity to $W_u$, a point in input space you can visualize, decode, or compare. "What does this neuron detect?" has a literal answer: whatever lives at $W_u$. A ReLU neuron's weight vector is a direction, and a direction does not have a preferred input.
+- **Exact attribution, no surrogate.** By the representer theorem (Kimeldorf & Wahba, 1971; Schölkopf et al., 2001), the readout is a weighted sum of kernel evaluations, so the contribution of center $u$ to an output is the kernel weight itself — an exact number, not a LIME/SHAP approximation fit after the fact. When the readout normalizes those weights it becomes a [Nadaraya–Watson estimator](/blog/readout-as-convex-combination/) and the contributions become a convex partition: "unit $u$ accounts for 30% of this output" is then a true statement, not a story.
+- **Capacity you can compute.** The RKHS norm of a unit at its peak is $k_{b,\varepsilon}(W_u, W_u) = (\lVert W_u\rVert^2 + b)^2/\varepsilon$ — a single scalar that measures how sharply the unit is tuned. Intensity, selectivity, and confidence stop being adjectives and become a quantity.
+- **A geometry on inputs.** The kernel induces a metric, and the induced metric is the object in which "similar input" is defined. The layer partitions input space into prototype basins you can draw.
+
+None of these are added by an explainability method. They are properties of the RKHS, available the moment the unit is a positive-definite kernel and gone the moment it is a pointwise activation.
+
+<YatAttribution caption="Reading the output, computed live on jax-js. A layer of Yat units, each a prototype carrying a message (its colour = the class it votes for). For the query you drag, the output is the exact convex combination f(x) = Σ aᵤ mᵤ with aᵤ = κ(x,Wᵤ)/Σκ — the representer theorem, not a fitted surrogate. The bars are the exact contribution of each prototype, and they always sum to one. The readout also shows the query's RKHS intensity (‖x‖²+b)²/ε, a capacity you compute rather than guess." />
+
+## Feature 3 — The geometry survives the layer
+
+A pointwise activation damages the geometry of the representation in ways that are now well documented: ReLU zeros coordinates and collapses rank, saturating activations flatten the pullback metric, and in high dimension these are the rule, not the exception — the full argument is [activations are bad for geometry](/blog/activations-are-bad-for-geometry/). The damage is structural: a function applied coordinate-wise cannot preserve angles and distances, because it does not know what the coordinates mean together.
+
+The kernel unit does not apply a function to the representation; it *measures* the representation against centers. Its level sets are distance contours around $W_u$, and the geometry the layer exposes is the kernel's induced geometry — informative by construction rather than degenerate by accident. You are not asking a nonlinearity to be selective without warping space, which is the impossible trade the activation is caught in. You are reading space with a ruler.
+
+## Feature 4 — No activation to choose, and no dead units
+
+The ReLU-versus-GELU-versus-SiLU question disappears, because the nonlinearity is the kernel and the kernel is fixed by the geometry, not the leaderboard. So does the **dead-unit pathology**: a ReLU unit whose pre-activation is negative over the data has exactly zero gradient and never recovers, a failure mode every large MLP pays for. A Yat unit has no off half-space. Its center always sits *somewhere*, always has a basin, and always receives a gradient pulling it toward the data it should explain. Units do not die; they migrate.
+
+<FeatureLearningFlow caption="Why a prototype migrates, computed live on the nanograd engine. The objective rewards kernel response to one class and penalises the other; its negative gradient is a force on the prototype's position, drawn here as a field (each arrow is a real backward pass). Drop the probe anywhere — it flows along the field onto the data it should detect. The point is that there is force everywhere: no half-space where the gradient vanishes, which is exactly why a Yat unit never dies the way a ReLU unit can." />
+
+## Feature 5 — A capacity functional, so regularization has a target
+
+Kernel machines come with a complexity measure that generalization bounds actually use: the RKHS norm. For the Yat unit that norm is the computable $(\lVert W_u\rVert^2 + b)^2/\varepsilon$ above, and bounding it bounds the function class — the Rademacher complexity of a kernel-weighted readout scales as $(R^2 + b)^2/(\varepsilon n)$ in the data radius $R$, through a single quantity rather than the product of every layer's spectral norm. Weight decay on a standard MLP regularizes a proxy (the parameter norm) for a quantity you cannot name (the function's complexity). Here the quantity has a name, and $\varepsilon$ is a direct dial on it: larger $\varepsilon$ flattens the kernel, lowers the RKHS norm, and widens the receptive field. The kernel form of the unit makes its own regularizer explicit. (The cleanest empirical evidence so far is on the attention side, where the Yat-kernel transformer shows a markedly smaller generalization gap than its softmax baseline; the MLP-side claim is the same mechanism and remains an empirical question.)
+
+## Feature 6 — The "finite" part: a feature map you can write down
+
+This is where the word *finite* earns its place. The Yat numerator $(W_u^\top x + b)^2$ is a polynomial kernel of degree two, and a degree-two polynomial kernel has an **exact, finite-dimensional feature map** $\phi_{\text{poly}}(x)$ of size $O(d^2)$ — the monomials $x_i x_j$, the linears $x_i$, and a constant. There is no infinite series to truncate, unlike the Gaussian RBF whose feature map is genuinely infinite. The IMQ denominator is not finite-rank, but it is exactly the regime where positive random features and quadrature work well — the same machinery (Rahimi & Recht, 2007; Choromanski et al., 2021) that makes [linear-time attention](/blog/linear-attention-jax-flax-nnx/) possible, and that I built and verified on the random-feature side in the [attention-kernel companion](/blog/attention-is-kernel-jax-flax-nnx/). So the whole unit is *linearizable*: a map $\phi$ with $k_{b,\varepsilon}(W_u, x) \approx \phi(W_u)^\top \phi(x)$, exact on the polynomial part and tightly approximable on the IMQ part. A kernel machine you can linearize is a kernel machine you can scale, and "finite" is the property that lets you.
+
+This is the kernel trick made spatial. The exact degree-2 feature map $\phi(x) = [x_1, x_2, x_1^2, x_2^2, x_1x_2, 1]$ turns a curved boundary into a *flat* one: a hyperplane in feature space is a conic in input space. Below, the flat separator is fitted on the engine (a least-squares solve in feature space), and the data is lifted into 3-D by its quadratic score. Raise the lift and the classes rise apart until a single flat plane slices between them; look at the floor and that same flat plane is a circle (rings) or a hyperbola (XOR). The spiral is the honest counter-example: degree two is not enough, so it never fully separates.
+
+<KernelTrickLift caption="The finite feature map doing the kernel trick, computed live on jax-js. The 2-D data is lifted into the exact degree-2 feature space by its quadratic score; the separating hyperplane is fitted on the engine with a least-squares solve. Drag 'lift' from 0 (flat, no straight line separates the classes) to 1 (lifted, one flat plane does). On the floor, that flat plane projects back to a conic boundary. Rings → a circle, XOR → a hyperbola, spiral → degree-2 is not enough (watch the accuracy). The whole scene rotates so you can see the lift." />
+
+## Feature 7 — Out-of-distribution inputs get a smaller answer, not a confident one
+
+Drive a ReLU MLP far off its training distribution and it extrapolates linearly to infinity: it returns a large, confident, usually wrong number, because a half-space has no boundary. A kernel that is peaked at its centers does the opposite. An input far from every prototype evaluates small against all of them, the unnormalized response decays, and the normalized readout has no strong mass to assign — a built-in "I am not near anything I know." Abstention and OOD-awareness are not a separate detection head; they are what a local kernel does when you leave the data.
+
+<YatExtrapolation caption="Off-distribution behaviour, computed live on jax-js. One ReLU unit and one Yat unit over a 1-D input; the shaded band is where the data lives. Drag the query out of the band: the ReLU pre-activation climbs without bound (a large, confident answer for an input it has never seen and leaves the top of the plot), while the Yat unit stays bounded — its response a fraction of its in-data peak. Unbounded extrapolation versus a bounded response is the difference between a half-plane and a kernel." />
+
+## Feature 8 — One primitive for the whole network
+
+Attention is already a kernel smoother — a Nadaraya–Watson estimator over tokens (Nadaraya, 1964; Watson, 1964; and the [attention post](/blog/attention-is-a-kernel/)). If the MLP unit is the same Yat kernel, then the feed-forward block and the attention block are the *same primitive* applied to different index sets: centers-and-inputs in the MLP, queries-and-keys in attention. One geometry, one attribution story, one capacity functional, end to end — instead of two unrelated mechanisms (a kernel smoother for mixing, an opaque MLP for transformation) that you have to interpret with two different toolkits. The GOAT family of Yat-kernel attention layers is the other half of this picture; together they describe a network whose every layer is readable for the same reason.
+
+## What it costs
+
+This is not free, and I want to be as honest as [the attention piece](/blog/attention-is-a-kernel/) was: I am not claiming the Yat MLP is a drop-in win over the transformer FFN at scale. That is an empirical question. Three real costs and caveats:
+
+- **Distances are not quite a matmul.** $\lVert x - W_u\rVert^2 = \lVert x\rVert^2 + \lVert W_u\rVert^2 - 2 W_u^\top x$ reduces to a matmul plus two norm vectors, so the asymptotics match a linear layer, but the constant and the memory traffic are higher than a single GEMM.
+- **Do not stack kernels.** The canonical block is $x \to \text{Yat} \to \text{Linear}$, not $\text{Yat}(\text{Yat}(\cdot))$; composing kernel units directly is a known anti-pattern in this line of work. The linear readout after the kernel is doing necessary work.
+- **The scalars and centers need care.** $b$ and $\varepsilon$ are admissibility-constrained (parameterize them through a softplus so they stay non-negative), and prototype initialization matters more than weight initialization in a ReLU net, because a center is a location, not just a scale.
+
+## The activation was always the missing kernel
+
+Strip the construction down and the claim is small. A neuron's job is to answer "how much does this input look like the thing I am tuned for?" The linear-plus-activation neuron answers it badly — a direction and a clamp, with no center, no metric, no honest attribution — and then we spend the rest of the stack, and an entire subfield, trying to recover the geometry the activation threw away. Put a finite, positive-definite kernel where the activation was and you do not *add* locality, explainability, geometry, and capacity control. They were always what a kernel is; the activation was the thing that hid them. As I put it before: the opacity of the standard MLP was never the price of expressivity. It was the price of giving up the kernel.
+
+---
+
+*The Yat kernel and its universality are from [Bouhsine (2026)](https://arxiv.org/abs/2605.03262). The kernel-unit construction and the prototype-versus-direction argument are developed in [what an MLP knows](/blog/what-an-mlp-knows/); the geometric cost of activations in [activations are bad for geometry](/blog/activations-are-bad-for-geometry/); the RKHS-explainability argument in [attention is explainable because it is a kernel](/blog/attention-is-a-kernel/). The Neural Tangent Kernel is [Jacot et al. (2018)](https://arxiv.org/abs/1806.07572) and the lazy regime [Chizat et al. (2019)](https://arxiv.org/abs/1812.07956); random features [Rahimi & Recht (2007)](https://people.eecs.berkeley.edu/~brecht/papers/07.rah.rec.nips.pdf) and [Choromanski et al. (2021)](https://arxiv.org/abs/2009.14794).*


### PR DESCRIPTION
Theory post: replace the activation function with a finite, positive-definite Yat kernel as the MLP unit, and catalogue what that buys (lazy loading, RKHS explainability, geometry, capacity control, a finite feature map, OOD-awareness, one primitive for MLP and attention).

Ships six fresh in-browser visualizations computed live on the engine (jax-js forward + nanograd autodiff), each verified against the real engine in Node:
- `YatMlpLearning` — live Yat-MLP training, prototypes migrating
- `LazyKernelRetrieval` — sparse activation / retrieval
- `YatAttribution` — exact representer-theorem contributions
- `YatExtrapolation` — bounded Yat vs unbounded ReLU off-distribution
- `KernelTrickLift` — 3-D lift into the exact degree-2 feature map (separator fit on the engine)
- `FeatureLearningFlow` — the force field that pulls a prototype onto its data

🤖 Generated with [Claude Code](https://claude.com/claude-code)