### PR TITLE
SEO: seoTitle field, trimmed descriptions, noindex thin tags

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,10 +1,34 @@
 import { defineConfig } from 'astro/config';
+import fs from 'node:fs';
+import path from 'node:path';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import rehypeSlug from 'rehype-slug';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
+
+// Tag pages with fewer than TAG_MIN published posts are thin content: they
+// rarely rank and dilute crawl/quality signals. The route noindexes them
+// (see src/pages/tag/[tag].astro) and we drop them from the sitemap here so
+// Search Console never sees a "submitted URL marked noindex" conflict. Kept in
+// sync with the `< 3` threshold in the tag route.
+const TAG_MIN = 3;
+function thinTags() {
+  const dir = './src/content/blog';
+  const count = {};
+  for (const f of fs.readdirSync(dir)) {
+    if (!/\.mdx?$/.test(f)) continue;
+    const fm = fs.readFileSync(path.join(dir, f), 'utf8').split(/^---$/m)[1] || '';
+    if (/^draft:\s*true/m.test(fm)) continue;
+    const m = fm.match(/^tags:\s*\[([^\]]*)\]/m);
+    if (!m) continue;
+    for (const t of m[1].split(',').map((x) => x.trim().replace(/^["']|["']$/g, '')).filter(Boolean))
+      count[t] = (count[t] || 0) + 1;
+  }
+  return new Set(Object.entries(count).filter(([, n]) => n < TAG_MIN).map(([t]) => t));
+}
+const THIN_TAGS = thinTags();
 
 export default defineConfig({
   site: 'https://tahabouhsine.com',
@@ -18,7 +42,16 @@ export default defineConfig({
     '/ai-illiteracy-pt1': '/blog/writeups/ai-illiteracy-pt1',
     '/poem-0-1': '/blog/writeups/poem-0-1',
   },
-  integrations: [mdx(), sitemap()],
+  integrations: [
+    mdx(),
+    sitemap({
+      // Drop thin (noindex'd) tag pages from the sitemap.
+      filter: (page) => {
+        const m = page.match(/\/tag\/([^/]+)\/?$/);
+        return m ? !THIN_TAGS.has(decodeURIComponent(m[1])) : true;
+      },
+    }),
+  ],
   markdown: {
     remarkPlugins: [remarkMath],
     rehypePlugins: [

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -28,6 +28,7 @@ interface BlogPostRef { url: string; title: string; description?: string; pubDat
 
 interface Props {
   title: string;
+  seoTitle?: string;
   description?: string;
   image?: string;
   type?: 'website' | 'article' | 'profile';
@@ -47,6 +48,7 @@ interface Props {
 
 const {
   title,
+  seoTitle,
   description = SITE_DESCRIPTION,
   image,
   type = 'website',
@@ -77,9 +79,13 @@ const baseUrl = `${SITE}${BASE}/`; // 'https://tahabouhsine.com/blog/'
 // For posts, use just the post title in <title>/og:title so SERP and social
 // cards get all ~60 chars for the headline. The site name still appears via
 // og:site_name and the JSON-LD publisher block.
-const fullTitle = type === 'article' || title === SITE_TITLE
-  ? title
-  : `${title} — ${SITE_TITLE}`;
+// `seoTitle` (when set) drives only the <title>/og/twitter headline so long
+// creative titles do not truncate in SERP; JSON-LD headline keeps full `title`.
+const fullTitle = seoTitle
+  ? seoTitle
+  : type === 'article' || title === SITE_TITLE
+    ? title
+    : `${title} — ${SITE_TITLE}`;
 
 // ─── Reading time → ISO 8601 duration ───────────────────────────────────
 // Used in BlogPosting.timeRequired. ~200 wpm reading-time default.

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -5,6 +5,10 @@ const blog = defineCollection({
   loader: glob({ pattern: '**/*.{md,mdx}', base: './src/content/blog' }),
   schema: z.object({
     title: z.string(),
+    // Short (<=60 char) title for the <title> tag / OG / Twitter only, so SERP
+    // and social headlines do not truncate. The on-page <h1> and JSON-LD
+    // headline keep the full creative `title`. Falls back to `title` when omitted.
+    seoTitle: z.string().optional(),
     description: z.string().optional(),
     // Short (<=160 char) meta description for SERP / OG / Twitter / JSON-LD. The
     // long `description` stays the on-page excerpt (cards, RSS, OG image); this is

--- a/src/content/blog/latent-on-the-spectrum-jax.mdx
+++ b/src/content/blog/latent-on-the-spectrum-jax.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Latent on the Spectrum, in JAX"
 description: "A runnable companion to Latent on the Spectrum: build a codebook as the spectral embedding of a label kernel in JAX (classical MDS with square-root eigenvalue scaling), watch a flat spectrum become the simplex and a graded one become the horseshoe, measure kernel-target alignment, split a representation into its between-class prototype frame and within-class information spectrum, and watch neural collapse grind the information to zero."
-seoDescription: "Spectral codebooks in JAX: classical MDS with square-root scaling, flat→simplex and graded→horseshoe spectra, kernel-target alignment, and the Σ_B/Σ_W information split."
+seoDescription: "Spectral codebooks in JAX: classical MDS, flat-to-simplex and graded-to-horseshoe spectra, kernel-target alignment, and the between/within-class split."
 pubDate: 2026-06-07T12:35:00-07:00
 draft: false
 tags: [ml, representation-learning, neural-collapse, simplex-etf, latent-space, spectral-embedding, kernel-methods, jax, implementation]

--- a/src/content/blog/latent-on-the-spectrum.mdx
+++ b/src/content/blog/latent-on-the-spectrum.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Latent on the Spectrum: Why Cats Sit Closer to Dogs Than to Cars'
+seoTitle: "Why Cats Sit Closer to Dogs Than Cars in Latent Space"
 description: 'The regular simplex is the perfect codebook only when classes are strangers. Real labels carry a similarity structure, and a latent space is a lossy, finite-dimensional encoding of a kernel, its codebook is the top eigenmodes of the label-similarity matrix. But the prototypes are only the top of the spectrum: the information lives in the modes below them, the continuum between prototypes, and the Welch bound sets the geometry of that channel. A follow-up to the Welch-bound post, with live in-browser experiments, steer a codebook from simplex to taxonomy and watch its spectrum, spend a dimension budget, watch supervision erase structure, watch neural collapse grind the information spectrum to zero, read dark knowledge off a feature wandering the frame, and see a structured codebook make better mistakes.'
 seoDescription: "A latent space is a finite encoding of a label-similarity kernel: its codebook is the top eigenmodes of that matrix, and the Welch bound sets the rest."
 pubDate: 2026-06-07T12:00:00-07:00

--- a/src/content/blog/not-all-infinities-are-equal.mdx
+++ b/src/content/blog/not-all-infinities-are-equal.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Not All Infinities Are Equal: The Cross-Entropy Asymmetry Behind Hallucination'
+seoTitle: "The Cross-Entropy Asymmetry Behind Hallucination"
 description: The singularity structure of cross-entropy is asymmetric, and that asymmetry explains LLM hallucination, the CLIP modality gap, and why contrastive losses need 32K batches.
 seoDescription: "Cross-entropy's singularity structure is asymmetric, and that explains LLM hallucination, the CLIP modality gap, and why contrastive losses need huge batches."
 pubDate: 2026-02-23

--- a/src/content/blog/opposite-is-not-different.mdx
+++ b/src/content/blog/opposite-is-not-different.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Opposite Is Not Different: The Cosine-Similarity Bug in CLIP and Contrastive Learning'
+seoTitle: "The Cosine-Similarity Bug in CLIP and Contrastive Learning"
 description: Maximum difference between two unit vectors is orthogonality (cos = 0), not opposition (cos = −1). CLIP, InfoNCE, and SimCLR have been optimizing for the wrong target for years.
 seoDescription: "Maximum difference between unit vectors is orthogonality (cos 0), not opposition (cos -1). CLIP, InfoNCE, and SimCLR optimize the wrong target."
 pubDate: 2026-02-22

--- a/src/content/blog/three-states-of-information-jax.mdx
+++ b/src/content/blog/three-states-of-information-jax.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Three States of Information, in JAX"
 description: "A runnable companion to The Three States of Information: train tiny models in JAX and measure the three states directly: the feature-covariance spectrum collapsing from high-rank (random) to a C−1-mode frame (structured), the distributional simplicity bias that fits low-order structure first (organized), the neural-collapse simplex where class-mean cosines lock onto −1/(C−1), and the alignment/uniformity split of contrastive learning running on two separate clocks. Four live JAX visualizations, every number an eigenvalue or a loss."
-seoDescription: "Three states of information in JAX: feature-covariance effective rank, simplicity bias, neural-collapse equiangularity (−1/(C−1)), and contrastive alignment vs uniformity."
+seoDescription: "Three states of information in JAX: effective rank, simplicity bias, neural-collapse equiangularity, and contrastive alignment versus uniformity."
 pubDate: 2026-06-07T12:40:00-07:00
 draft: false
 tags: [ml, training-dynamics, representation-learning, neural-collapse, simplex-etf, contrastive, phase-transitions, jax, implementation]

--- a/src/content/blog/untangling-the-moons.mdx
+++ b/src/content/blog/untangling-the-moons.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Untangling the Moons: A Visual History of Contrastive Learning'
+seoTitle: "Untangling the Moons: Contrastive Learning Visualized"
 description: Eight contrastive losses, twenty years of history, one interactive playground. Watch pair, triplet, InfoNCE, CLIP, SupCon, SigLIP, alignment+uniformity, and cosine→0 organize 2D points, and see which ones know when to stop.
 seoDescription: "Eight contrastive losses (pair, triplet, InfoNCE, CLIP, SupCon, SigLIP, alignment+uniformity, cosine) organizing 2D points in one interactive playground."
 pubDate: 2026-05-26

--- a/src/content/blog/welch-bound-good-latent-space.mdx
+++ b/src/content/blog/welch-bound-good-latent-space.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'What Makes a Good Latent Space? The Welch Bound and the Simplex'
+seoTitle: "What Makes a Good Latent Space? The Welch Bound"
 description: 'A visual story about the hidden codebook inside representation learning: why collapse happens, why opposition is a trap, why class means form a simplex, and why the Welch bound from radio engineering tells us the best possible geometry when too many concepts share too few dimensions.'
 seoDescription: "Why class means form a simplex, and why the Welch bound from radio engineering gives the best latent geometry when too many concepts share too few dimensions."
 pubDate: 2026-06-02

--- a/src/content/blog/what-a-finite-kernel-buys-an-mlp.mdx
+++ b/src/content/blog/what-a-finite-kernel-buys-an-mlp.mdx
@@ -1,7 +1,7 @@
 ---
 title: "What a Finite Kernel Buys an MLP"
 description: "Replace the activation function with a finite, explicit, positive-definite kernel, the Yat kernel, and an MLP stops being a stack of linear maps glued by a nonlinearity. It becomes a kernel machine, with locality, attribution, geometry, capacity control, and a feature map you can write down."
-seoDescription: "Replacing the activation in an MLP with the finite, positive-definite Yat kernel turns it into a kernel machine: locality, attribution, geometry, and capacity control."
+seoDescription: "Replacing the MLP activation with the finite, positive-definite Yat kernel turns it into a kernel machine: locality, attribution, geometry, capacity control."
 pubDate: 2026-06-18
 companion: yat-mlp-jax-flax-nnx
 tags: [ml, kernels, interpretability, mlp, rkhs, yat, geometry, deep-learning]

--- a/src/content/blog/yat-mlp-fmnist-jax-flax-nnx.mdx
+++ b/src/content/blog/yat-mlp-fmnist-jax-flax-nnx.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Your Neuron Is a Picture, in JAX/Flax NNX"
 description: "A runnable companion: build the prototype MLP from the post in Flax NNX, train it on Fashion-MNIST, and watch the neurons. Pull the prototypes out as images, read a prediction as a vote over pictures, see the model abstain on out-of-distribution digits, check that random-init prototypes classify but stay noise, and track the prototypes migrating through a UMAP fit on the dataset as they train."
-seoDescription: "Build a Yat-kernel MLP on Fashion-MNIST in Flax NNX: prototypes as images, prediction as a vote over pictures, OOD abstention, and UMAP-tracked prototype trajectories."
+seoDescription: "Build a Yat-kernel MLP on Fashion-MNIST in Flax NNX: prototypes as images, prediction as a vote over pictures, OOD abstention, and UMAP prototype paths."
 pubDate: 2026-06-21T10:00:00-07:00
 draft: false
 tags: [ml, kernels, interpretability, mlp, yat, prototypes, jax, flax, nnx, implementation, deep-learning]

--- a/src/content/blog/your-neuron-is-a-picture.mdx
+++ b/src/content/blog/your-neuron-is-a-picture.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Your Neuron Is a Direction. It Should Be a Picture."
 description: "Why should a neuron store a direction when it could store a thing? A direction is not a referent you can point at, which is why MLPs are opaque. Put the Yat kernel where the activation was, train on Fashion-MNIST, and every neuron becomes a prototype that lives in pixel space, literally a picture, so the network reads its own predictions: this looks like that, no saliency method required."
-seoDescription: "A direction tells you which way; a prototype tells you which thing. A Yat-kernel MLP on Fashion-MNIST where each neuron is a picture, so every prediction explains itself."
+seoDescription: "A direction tells you which way; a prototype tells you which thing. A Yat-kernel MLP on Fashion-MNIST where each neuron is a picture that explains itself."
 pubDate: 2026-06-21
 draft: false
 companion: yat-mlp-fmnist-jax-flax-nnx

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -9,6 +9,7 @@ interface BlogPostRef { url: string; title: string; description?: string; pubDat
 
 interface Props {
   title: string;
+  seoTitle?: string;
   description?: string;
   image?: string;
   type?: 'website' | 'article' | 'profile';

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -15,6 +15,7 @@ interface Pair { role: 'explainer' | 'companion'; slug: string; title: string }
 interface Reference { key?: string; authors: string; year: number | string; title: string; venue?: string; url?: string; arxiv?: string; doi?: string }
 interface Props {
   title: string;
+  seoTitle?: string;
   description?: string;
   draft?: boolean;
   pair?: Pair;
@@ -32,6 +33,7 @@ interface Props {
 }
 const {
   title,
+  seoTitle,
   description,
   draft,
   pair,
@@ -56,6 +58,7 @@ const postSlug = base && postPath.startsWith(`${base}/`)
 ---
 <BaseLayout
   title={title}
+  seoTitle={seoTitle}
   description={description}
   image={heroImage}
   type="article"

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -57,6 +57,7 @@ const stats = readingTime(post.body ?? '');
 ---
 <PostLayout
   title={post.data.title}
+  seoTitle={post.data.seoTitle}
   description={post.data.seoDescription ?? post.data.description}
   draft={post.data.draft}
   pair={pair}

--- a/src/pages/tag/[tag].astro
+++ b/src/pages/tag/[tag].astro
@@ -47,7 +47,7 @@ const collectionLd = {
   },
 };
 ---
-<BaseLayout title={meta.title} description={meta.description}>
+<BaseLayout title={meta.title} description={meta.description} noindex={posts.length < 3}>
   <p class="meta"><a href={`${base}/tags`}>← all tags</a></p>
   <h1>{meta.name}</h1>
   <p class="lead">{meta.description}</p>


### PR DESCRIPTION
Applies the fixes from the SEO audit.

- **seoTitle frontmatter** — optional short title for the title tag, og:title and twitter:title only; the on-page h1 and JSON-LD headline keep the full creative title. Set on the 5 posts whose titles exceeded ~60 chars so they no longer truncate in SERP. Wired BaseHead, BaseLayout, PostLayout and the slug route.
- **Trimmed 5 meta descriptions** from 167-171 to 160 chars or fewer.
- **Thin tag pages** (fewer than 3 published posts) now emit noindex,nofollow and are filtered out of the sitemap (thin-tag set computed in astro.config). 41 thin pages noindex'd, 27 substantial tag pages remain indexable and in the sitemap.

Verified via production build: the title tag uses seoTitle while h1 and schema keep the full title; thin tags carry robots noindex and are absent from sitemap-0.xml; all descriptions 160 chars or fewer, all seoTitles 60 or fewer; no em dashes.

Generated with Claude Code
