### PR TITLE
SEO: Twitter/X attribution (@mlnomadpy)

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -13,6 +13,7 @@ import {
   SITE_AUTHOR,
   SITE_AUTHOR_URL,
   SITE_AUTHOR_JOB_TITLE,
+  SITE_TWITTER,
   SITE_SAMEAS,
   SITE_OG_IMAGE,
   GA4_MEASUREMENT_ID,
@@ -296,6 +297,8 @@ const jsonLdNodes = [blogPosting, breadcrumb, website, blogIndex, profilePage].f
 
 {/* Twitter Card — always large image since we have a default fallback */}
 <meta name="twitter:card" content="summary_large_image" />
+{SITE_TWITTER && <meta name="twitter:site" content={`@${SITE_TWITTER}`} />}
+{SITE_TWITTER && <meta name="twitter:creator" content={`@${SITE_TWITTER}`} />}
 <meta name="twitter:title" content={fullTitle} />
 <meta name="twitter:description" content={description} />
 <meta name="twitter:image" content={ogImage} />

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -9,10 +9,15 @@ export const SITE_AUTHOR_URL = 'https://github.com/mlnomadpy';
 export const SITE_AUTHOR_JOB_TITLE = 'Machine Learning Researcher';
 export const BUY_ME_A_COFFEE_URL = 'https://buymeacoffee.com/mlnomadpy';
 
+// X / Twitter handle (no @). Emitted as twitter:site and twitter:creator so
+// Twitter/X cards attribute the author. Leave empty to omit the tags.
+export const SITE_TWITTER = 'mlnomadpy';
+
 // sameAs URLs — used in JSON-LD Person/Publisher schema and as <link rel="me">
 // for IndieWeb / Mastodon verification and Google's author-discovery signal.
 export const SITE_SAMEAS: readonly string[] = [
   'https://github.com/mlnomadpy',
+  'https://x.com/mlnomadpy',
   'https://www.linkedin.com/in/tahabsn/',
   'https://scholar.google.com/citations?user=IsBjb3EAAAAJ',
   'https://g.dev/tahabsn',


### PR DESCRIPTION
Adds twitter:site and twitter:creator (@mlnomadpy) via a new SITE_TWITTER const, and adds the X profile to the JSON-LD sameAs for author-discovery. Verified in a production build.