### PR TITLE
Edit: stronger opening, tighter prose, kernel math for the editable-network pair

### DIFF
--- a/src/content/blog/edit-a-network-by-hand.mdx
+++ b/src/content/blog/edit-a-network-by-hand.mdx
@@ -44,39 +44,63 @@ import AttractorField from '../../components/viz/AttractorField.astro';
 import TeachByExample from '../../components/viz/TeachByExample.astro';
 import ForgetMatch from '../../components/viz/ForgetMatch.astro';
 
-*A [previous post](/blog/your-neuron-is-a-picture/) showed that if you put the Yat kernel where a neuron's activation was, the neuron stops being a direction and becomes a prototype: a point in input space, which on images is literally a picture. One consequence got a paragraph there and deserves a whole post here. If a neuron is a picture, then a network is a list of pictures, and a list is something you can edit. You can hand it a new class without training it, and you can make it forget a class without training it. Both turn out to be things the rest of deep learning struggles to do at all. Every number below is from a real run; the script is `scripts/yat_editable_fmnist.py`.*
+*To make this network forget a class, you delete a few rows of a matrix. To teach it a new one, you paste a few rows in. No gradient steps either way, and you can diff the weights afterward to check that nothing else moved. Both of those are supposed to be hard. Teaching a deployed model a new class without wrecking the old ones is the problem people call catastrophic forgetting; making a model genuinely forget what it learned is machine unlearning, the one courts have started asking about. They are hard because of how an ordinary network stores a class, and easy here because of how this one does. A [previous post](/blog/your-neuron-is-a-picture/) swapped a neuron's activation for the Yat kernel, which turns the neuron from a direction into a prototype: a point in input space, and on an image a literal picture. A network of those is a list of pictures, and a list is something you edit by hand. Every number below comes from a real run; the script is `scripts/yat_editable_fmnist.py`.*
 
 ## A network you edit instead of train
 
-Here is the move the whole post rests on. A standard neuron stores a direction $w$, and a direction is not a thing you can point at. You cannot hand-write a useful direction, you cannot read one off, and you certainly cannot edit a network by editing its directions. Training is the only way in, because the weights mean nothing until gradient descent fills them with meaning.
+A standard neuron stores a direction $w$. You cannot point at a direction: you cannot hand-write a useful one, read meaning off one, or edit a network by rewriting them. Training is the only way in, because the weights mean nothing until gradient descent puts meaning there.
 
-A Yat unit stores a prototype $W_u$ and scores an input by a kernel against it, $\phi_u(x) = (W_u^\top x + b)^2 / (\lVert x - W_u\rVert^2 + \varepsilon)$. The prototype lives in the same space as the data, so it is a referent you can point at: on Fashion-MNIST it is a 28x28 picture of a piece of clothing. A classifier is then a bank of these prototypes plus a readout that lets each one vote for its class. The earlier post built exactly this by hand, k-means centroids as the prototypes and a one-hot readout, and reached **79%** on Fashion-MNIST with zero gradient steps.
+A Yat unit stores a prototype $W_u$ instead, and scores an input by a kernel against it, $\phi_u(x) = (W_u^\top x + b)^2 / (\lVert x - W_u\rVert^2 + \varepsilon)$. The prototype sits in the same space as the data, so you can point at it: on Fashion-MNIST it is a 28x28 picture of a piece of clothing. A classifier is a bank of these prototypes and a readout where each one votes for its class. Built by hand from k-means centroids and a one-hot readout, with no gradient steps at all, it reaches **79%** on Fashion-MNIST.
 
-Before we edit it, look at how it decides, because the editing only makes sense once you see the vote. Pick an image below and the kernel against all 200 prototypes is computed live in your browser: every atom is a prototype, it brightens by how much the image resembles it, the readout lines carry that resemblance to the class outputs, and the loudest output wins. There is no hidden machinery; the prediction *is* this vote over pictures.
+Write that as vectors; the edits later are one line each off it. Stack the $K$ activations into $\phi(x) = (\phi_1(x), \dots, \phi_K(x)) \in \mathbb{R}^K_{\ge 0}$, and let the readout be a matrix $A \in \{0,1\}^{K \times C}$ with row $u$ one-hot at unit $u$'s class. The class scores are the readout applied to the activations,
+
+$$
+s(x) = A^\top \phi(x) \in \mathbb{R}^C, \qquad s_c(x) = \sum_{u\,:\,\text{class}(u)=c} \phi_u(x), \qquad \hat y(x) = \arg\max_c\, s_c(x).
+$$
+
+Two things about that sum come back later. A class's score uses only its own prototypes; no other class appears in $s_c$. And the prototypes enter additively, one term each. Teaching adds terms, forgetting removes them, and everything else follows.
+
+First, though, how it decides. Pick an image below and the kernel against all 200 prototypes runs in your browser. Each atom is a prototype, brightening with resemblance; the readout carries those resemblances to the ten class outputs, and the loudest wins. The prediction is that vote, with nothing behind it.
 
 <KernelVote caption="A prediction as a vote over prototype pictures, computed live. Each atom is one of the 200 prototypes (20 per class); pick an image and its Yat-kernel activation against every prototype is evaluated in the browser. Atoms brighten with resemblance, the readout lines carry the vote to the ten class outputs, and the strongest output wins. This is the whole forward pass: similarity to stored pictures, summed by class." />
 
+## Each class is one vector
+
+The kernel theory under this is in the [previous post](/blog/your-neuron-is-a-picture/): $\phi_u(x) = k(x, W_u)$ is a positive-definite kernel with an RKHS feature map $\Phi$, so $\phi_u(x) = \langle\Phi(x),\Phi(W_u)\rangle_{\mathcal H}$, and the centers sit in input space, which is what makes them pictures. One line of it is useful here. The sum over a class slides inside the inner product,
+
+$$
+s_c(x)=\sum_{u\in c}\langle\Phi(x),\Phi(W_u)\rangle_{\mathcal H}=\langle\Phi(x),\,\mu_c\rangle_{\mathcal H},\qquad \mu_c:=\sum_{u\in c}\Phi(W_u).
+$$
+
+A class is now one vector $\mu_c\in\mathcal H$, the mean of its prototypes in feature space, and the network picks the nearest one, $\hat y(x)=\arg\max_c\langle\Phi(x),\mu_c\rangle$, a Parzen-window vote. Ten classes, ten independent vectors, a score linear in each. Move one $\mu_c$ and the other nine inner products do not change. That is the version of the post in one sentence; the rest is watching it happen.
+
 ## The network is a landscape of wells
 
-There is a physical picture hiding in the kernel, and once you see it the rest of the post stops being a list of tricks and becomes one idea. Look at the denominator: $1 / (\lVert x - W_u\rVert^2 + \varepsilon)$. That is a softened inverse-square law, the same shape as gravity and electrostatics. The $\varepsilon$ is not a hack either; it is exactly the *softening length* that N-body simulations add to keep the force finite when two bodies coincide. So each prototype is a little mass, and it digs a well into the input space whose pull falls off with the square of the distance.
+The denominator repays a second look. $1 / (\lVert x - W_u\rVert^2 + \varepsilon)$ is a softened inverse-square law, the shape of gravity and of electrostatics, and the $\varepsilon$ is its softening length, the same constant an N-body simulation adds so the force stays finite when two bodies meet. Read that way, a prototype is a mass. It digs a well into input space whose pull falls off with the square of the distance.
 
-A bank of prototypes is therefore a landscape of wells, one cluster of wells per class. Classifying a point is letting it fall into the deepest basin it can feel. The decision boundary is the watershed between basins, the ridge where two wells pull equally. Drag the marker below across that ridge and you can watch its allegiance flip.
+A bank of prototypes is then a landscape of wells, one cluster per class, and the class score is its field: $s_c(x) = \sum_{u\in c} \phi_u(x)$ sums class $c$'s wells the way a gravitational field sums the potentials of its masses. A point is classified by the deepest basin it can feel, $\hat y(x) = \arg\max_c s_c(x)$, and the boundary is the watershed where two fields come out even, $\{x : s_c(x) = s_{c'}(x)\}$. Far from every prototype the field stays bounded instead of blowing up, so a point that looks like nothing settles nowhere and the network can hold back. Drag the marker below across a ridge and its class flips.
 
 <AttractorField caption="The kernel as a field of attractors, in 2D where you can see it. Each prototype is a well with a 1/(r²+ε) pull, a softened inverse-square law (ε is the gravitational softening length). The plane is coloured by which basin wins, darkening to a watershed at the boundaries. Press “drop test particles” and they fall into the basins, coloured by the class they land in, which is the whole act of classification. Drag the white marker to feel the pull flip as it crosses a ridge. Click a well to delete it: its basin collapses and the neighbours flood in to reclaim the ground, while the rest of the landscape does not move. A 2D physics illustration of the same kernel the rest of the post runs on Fashion-MNIST." />
 
-This picture pays for itself immediately, because the two edits the rest of the post is about become physical moves on the landscape. Teaching a class is dropping a new mass: it opens a fresh basin where there was none. Forgetting a class is removing a mass: its basin collapses and the neighbours reclaim exactly the territory it held, and nowhere else, which is *why* the forgetting is exact. And because fields superpose, the total landscape is just the sum of the wells, independent of the order you placed them, which is why teaching incrementally lands in the same place as building all at once. One inverse-square law, and the vote, the teaching, the forgetting, and the order-independence are all the same fact.
-
-Now watch those two moves on the real network.
+The two edits ahead are moves on this landscape. Teaching drops a new mass and opens a basin where there was none. Forgetting takes a mass away; its basin caves in and the neighbours spread into exactly the ground it held, no further, which is what makes the forgetting exact. Fields add, so the landscape is the sum of its wells no matter the order they arrived, and teaching one class at a time ends where building all ten at once does. Underneath the vote, the teaching, the forgetting, and the order-independence sits one inverse-square law.
 
 ## Teach it a class, no training
 
 Start with a deliberately incomplete model: a hand-built classifier that has only ever seen eight of the ten classes. It places twenty prototypes for each of classes 0 through 7 and knows nothing about Bag or Boot. On the test images of the classes it does know, it scores **77.8%**.
 
-Now teach it the two missing classes the only way an editable network needs: take twenty example images of Bag and twenty of Boot, drop them in as new prototypes, and add a readout row for each so they can vote. Forty pictures placed. No optimizer, no backward pass, no epochs.
+Now teach it the two it is missing. Take twenty example images of Bag and twenty of Boot, drop them in as new prototypes, and give each a readout row so it can vote. Forty pictures placed, no optimizer, no backward pass, no epochs.
 
 The model now recognizes **Bag at 95%** and **Boot at 94%**, classes it had never encountered a moment ago. And the classes it already knew barely flinch: accuracy on classes 0 through 7 moves from 77.8% to 75.6%, a two-point dip that comes only from the new prototypes occasionally sitting closer to an old test image, not from anything being overwritten. Overall, across all ten classes, it scores **79.4%**.
 
-Here is the part worth sitting with. A model built on all ten classes from the very start, the normal way, also scores **79.4%**. Adding the two classes incrementally, after the fact, by hand, cost nothing. The incremental network and the all-at-once network land on the same number, because there is no "after the fact" for a list. A prototype you place last works exactly like a prototype you placed first.
+A model built on all ten classes from the start scores **79.4%** too. Adding the two after the fact cost nothing, because for a list there is no "after the fact": a prototype placed last behaves exactly like one placed first.
+
+The algebra says why in a line. Teaching class $c$ appends rows $(W_c, e_c)$ to $(W, A)$, each new readout row one-hot at $c$. For any other class $c' \ne c$, the new units contribute $A_{u,c'}\,\phi_u(x) = 0$, so
+
+$$
+s_{c'}(x) \;\text{is unchanged, exactly,} \qquad s_c(x) \;\mapsto\; s_c(x) + \sum_{u \in \text{new}} \phi_u(x).
+$$
+
+Only the taught class's score moves. An old image gets relabelled only if the new $s_c$ now beats its previous winner, never because its own class was corrupted underneath it, which is the two-point dip and not a point more. And a sum does not remember the order of its terms, so teaching one class at a time and building all ten at once give the identical score function. Order-independence is just addition commuting, which was the fields superposing seen from the other side.
 
 <TeachByExample caption="Teaching, made concrete. Left is the network's memory: ten labelled bins, empty to start, so it knows nothing and guesses every held-out test image (right) wrong. Click a class to teach it: you drop in that class's example pictures, no training, and every test image of that class flips from a red wrong guess to a green correct one at once. Knowledge here is just labelled example pictures, and teaching is adding some. Teach all ten and it recognizes 81% of a held-out sample, where a from-scratch build also lands (the text quotes 79.4% on the full test set)." />
 
@@ -90,25 +114,29 @@ The edit is the obvious one. Find the twenty prototypes that vote for Sandal, de
 
 Sandal recall goes from **64% to 0%**. The class is gone; nothing in the network resembles a sandal anymore, so nothing can be classified as one. And the other nine classes go from **81.1% to 81.3%**, untouched, in fact a hair better, because the deleted prototypes are no longer around to occasionally steal a test image that belonged to someone else. The forgetting is exact and surgical. You removed precisely one capability and left the rest of the network bit-for-bit identical.
 
+The sum makes that provable. For any surviving class $c' \ne c$, the score $s_{c'}(x) = \sum_{u \in c'} \phi_u(x)$ never named one of class $c$'s rows, so deleting them does nothing to it: $s_{c'}$ is the function it was, term for term, while $s_c$ empties out. The other nine are not *approximately* preserved, the way a fine-tuned or gradient-scrubbed model leaves them. They are identical, and you can diff the weight matrices to see it. That is the line between approximate and exact unlearning: not "we lowered its influence and hope," but "the rows are gone, check."
+
 <ForgetMatch caption="Why forgetting is exact, made visible. The network recognizes each test image (left) by the single prototype it most resembles (right): that match is the decision, and its class is the label. Click a class in the memory strip to delete it. The images that were recognized by that class lose their match and re-point to a surviving prototype, usually wrong now (shown in red, “re-routed”); every other image keeps the exact same match and label, untouched. Delete Sandal and only the sandals break, which is the whole claim: removing a class disturbs only what relied on it. Matches are computed live on jax-js." />
 
-Delete any class above and only its line drops; the other nine hold flat, which is the whole claim made visible.
+Delete any class above and only its line drops; the other nine hold flat. That is the claim, on screen.
 
 ## Why this is supposed to be hard
 
-If you have trained neural networks, both of those results should feel slightly illegal, because in an ordinary network they are famously, expensively hard.
+If you train networks for a living, both results are the kind you double-check. In an ordinary network they are expensive, and the second one is barely possible at all.
 
 Teaching a trained network a new class usually means fine-tuning, and fine-tuning on the new class degrades the old ones. The phenomenon has a name, [catastrophic forgetting](https://arxiv.org/abs/1612.00796), and it is old enough to have been described in 1989. An entire subfield, continual learning, exists to fight it with rehearsal buffers, regularizers that pin important weights in place, and dynamically grown sub-networks. The reason the fight is necessary is structural: in a network of directions, knowledge is smeared across shared weights, so every new gradient step writes over a little of everything that came before. There is no row you can point to that *is* the old class, so there is no way to protect it except indirectly.
 
 Unlearning is worse. "Make the model forget these training examples" is a live research problem, [machine unlearning](https://arxiv.org/abs/1912.03817), driven by privacy law and the right to be forgotten, and the honest baseline for doing it correctly is to throw the model away and retrain from scratch on the data minus the part you want gone. Everything cheaper is an approximation that you then have to audit, because the forgotten data left its fingerprints distributed across all the weights and you can never quite prove you wiped them.
 
-The Yat network sidesteps both, not by being cleverer, but by storing knowledge in a form you can address. A class is not smeared across the weights; it *is* a contiguous set of prototypes. So protecting it during an edit is trivial (do not touch those rows) and erasing it is exact (delete exactly those rows, and provably nothing else carries the class). Continual learning and unlearning stop being algorithms you run and become slices you take.
+Write the ordinary classifier's score the same way and the reason shows. Its logit for class $c$ is $z_c(x) = w_c^\top h(x)$, with $h(x)$ a representation every class shares. Class $c$ lives a little in its head $w_c$ and mostly, diffusely, in the weights that build $h$, which the other classes read from too. You cannot move $c$ without moving $h$, and moving $h$ tilts every $z_{c'}$ at once. The entanglement is not a training artifact; it is the data path. Set that beside $s_c(x) = \sum_{u \in c} \phi_u(x)$, where class $c$ reaches only its own units: a shared $h(x)$ against a partitioned $\phi(x)$.
+
+The Yat network sidesteps both problems, then, not by being cleverer, but by storing knowledge in a form you can address. A class is not smeared across the weights; it *is* a contiguous set of prototypes. So protecting it during an edit is trivial (do not touch those rows) and erasing it is exact (delete exactly those rows, and provably nothing else carries the class). Continual learning and unlearning stop being algorithms you run and become slices you take.
 
 ## The boundary, and where this goes
 
-I want to be precise about the edge of the claim, because the precise version is more interesting than the hype. None of this is free in general; it is free *here*, on raw pixels, because the input space is the feature space. A prototype can be a legible, placeable, deletable picture only because the thing the kernel compares against lives where the data lives. The moment you put the Yat kernel on top of learned features, a prototype becomes an exemplar in feature space, and those features still cost a training run. "No training" narrows to "no training of the head, given features."
+None of this is free in general. It is free *here*, on raw pixels, because the input space is the feature space. A prototype can be a legible, placeable, deletable picture only because what the kernel compares against lives where the data lives. Put the Yat kernel on top of learned features and a prototype becomes an exemplar in feature space, and those features still cost a training run; "no training" narrows to "no training of the head, given features."
 
-That narrowing is not a retreat. It is the actual question this whole line of work circles: how much of a network can you *construct* rather than *optimize*, and how deep can the construction go before you are forced to learn? On pixels, the answer is the entire classifier. With features, the answer is the entire classifier on top of a learned backbone, which is already the regime where editing, adding, and forgetting matter most in practice. That boundary, construction versus optimization, is the subject of the next post. For now the smaller claim stands on its own and is worth saying plainly: a network whose neurons are pictures is not a black box you fill by training. It is a document you write, and revise, by hand.
+The narrowing is not a retreat, it is the real question. How much of a network can you *construct* instead of *optimize*, and how far down does the construction reach before you have to learn? On pixels, the whole classifier. On learned features, the whole classifier on top of a trained backbone, which is where adding and forgetting matter most anyway. That part is for next time. The smaller claim holds on its own: a network whose neurons are pictures is not a black box you fill by training. It is a document you write, and revise, by hand.
 
 ---
 

--- a/src/content/blog/edit-a-network-jax-flax-nnx.mdx
+++ b/src/content/blog/edit-a-network-jax-flax-nnx.mdx
@@ -61,7 +61,7 @@ class YatEdit(nnx.Module):
         return self.kernel(x) @ self.A.value          # kernel votes -> class scores
 ```
 
-There is no `nnx.Linear`, no nonlinearity, and crucially no entanglement: prototype $u$ lives entirely in row $u$ of `W` and row $u$ of `A`. That separation is the whole reason the edits below are clean.
+There is no `nnx.Linear`, no nonlinearity, and crucially no entanglement: prototype $u$ lives entirely in row $u$ of `W` and row $u$ of `A`. In symbols the forward pass is $s(x) = A^\top \phi(x)$ with $\phi(x) \in \mathbb{R}^K_{\ge 0}$ the kernel activations, and because the rows of $A$ are one-hot, the per-class score is a sum over only that class's units, $s_c(x) = \sum_{u\,:\,\text{class}(u)=c} \phi_u(x)$. Every edit below is a consequence of that sum: appending rows adds terms, masking rows removes them, and a term for class $c$ never appears in any other class's score.
 
 ## Build it by hand
 
@@ -130,7 +130,7 @@ print("all 10:", round(float((jnp.argmax(eight(jnp.asarray(Xte)), -1) == yte).me
 print("from scratch:", round(float((jnp.argmax(build(range(10))(jnp.asarray(Xte)), -1) == yte).mean()) * 100, 1))  # 79.4
 ```
 
-The two classes it had never encountered are recognized at **95%** and **94%** the moment their rows are appended, and the classes it already knew barely move. The headline is the last two lines: the network taught incrementally and the network built on all ten at once reach the **same 79.4%**, because a row appended last is identical to a row placed first. There is no penalty for incrementality, and no rehearsal buffer in sight.
+The two classes it had never encountered are recognized at **95%** and **94%** the moment their rows are appended, and the classes it already knew barely move. The reason is one line of the algebra: the appended rows are one-hot at the new class $c$, so for every other class $c' \ne c$ their contribution to $s_{c'}$ is zero and $s_{c'}(x)$ is left exactly as it was, while $s_c(x) \mapsto s_c(x) + \sum_{u \in \text{new}} \phi_u(x)$ gains the new terms. Old-class scores are invariant under the `concatenate`. The headline is the last two lines: the network taught incrementally and the network built on all ten at once reach the **same 79.4%**, because $s_c$ is a sum and a sum does not remember the order its terms arrived in. There is no penalty for incrementality, and no rehearsal buffer in sight.
 
 <figure class="jax-fig jax-fig-wide">
   <img src="/blog/edit-teach.gif" alt="A 2D map of Fashion-MNIST where basins of attraction grow in one class at a time as their prototype masses fade into the landscape, with no training" loading="lazy" width="440" height="422" />
@@ -156,7 +156,7 @@ print("Sandal recall:", recall(m, 5))                  # 0
 print("other 9 recall:", round(before, 1), "->", round(np.mean([recall(m, c) for c in others]), 1))  # 81.1 -> 81.3
 ```
 
-Sandal recall goes to **0**: nothing in the network resembles a sandal anymore, so nothing can be labelled one. The other nine classes go from **81.1%** to **81.3%**, untouched, a hair better because the deleted rows are no longer around to occasionally steal a neighbour's test image. The forgetting is exact and you can prove it: every surviving row of `W` and `A` is bit-for-bit identical to before.
+Sandal recall goes to **0**: nothing in the network resembles a sandal anymore, so nothing can be labelled one. The other nine classes go from **81.1%** to **81.3%**, untouched, a hair better because the deleted rows are no longer around to occasionally steal a neighbour's test image. The forgetting is exact and the same identity proves it: for $c' \ne 5$, $s_{c'}(x) = \sum_{u \in c'} \phi_u(x)$ never indexed a Sandal row, so masking those rows out is a no-op on it, and every surviving entry of `W` and `A` is bit-for-bit identical to before. This is the line between exact unlearning and the approximate kind: not "we reduced its influence and hope," but "the rows are not in the matrix, check."
 
 <figure class="jax-fig jax-fig-wide">
   <img src="/blog/edit-forget.gif" alt="A 2D map of Fashion-MNIST where the Sandal basin collapses as its prototype masses fade to zero and neighbouring basins flood in to reclaim the territory, the rest unchanged" loading="lazy" width="440" height="422" />


### PR DESCRIPTION
Narrative and math revision of the already-published editable-network pair; no results change.

- Explainer opening now leads with the edit and the two named hard problems (catastrophic forgetting, machine unlearning) instead of recapping a prior post; removed self-announcing / tell-the-reader-how-to-feel phrasing throughout and varied the rhythm.
- Added the score algebra and the per-class kernel mean embedding, so teaching and forgetting read as short corollaries; grounded the inverse-square / superposition framing in it and pointed to the prior post for the RKHS foundations rather than re-deriving them.
- Companion: matching identities inline with the concatenate and the mask.

Generated with Claude Code