### PR TITLE
Publish writeup: The Universe Is the Better Teacher

### DIFF
--- a/src/content/writeups/the-universe-is-the-better-teacher.mdx
+++ b/src/content/writeups/the-universe-is-the-better-teacher.mdx
@@ -4,7 +4,7 @@ description: We keep aiming the universal approximator at a single function — 
 seoDescription: We aim the universal approximator at one function, human intelligence, and a copy cannot surpass its teacher. To exceed us, train against the universe.
 pubDate: 2026-06-24
 tags: [ai, philosophy, universal-approximation, intelligence, physics, notes]
-draft: true
+draft: false
 ---
 
 There is a theorem that sounds like a promise. A neural network with enough

--- a/src/content/writeups/the-universe-is-the-better-teacher.mdx
+++ b/src/content/writeups/the-universe-is-the-better-teacher.mdx
@@ -1,0 +1,124 @@
+---
+title: The Universe Is the Better Teacher
+description: We keep aiming the universal approximator at a single function — human intelligence — and a copy can never surpass its teacher. To exceed us, the model needs a teacher that already exceeds us: the universe and its laws.
+seoDescription: We aim the universal approximator at one function, human intelligence, and a copy cannot surpass its teacher. To exceed us, train against the universe.
+pubDate: 2026-06-24
+tags: [ai, philosophy, universal-approximation, intelligence, physics, notes]
+draft: true
+---
+
+There is a theorem that sounds like a promise. A neural network with enough
+width can approximate any continuous function to whatever precision you like.
+Cybenko proved it for sigmoids in 1989, Hornik made it general two years later,
+and ever since we have repeated it as a kind of charm: the network can learn
+*anything*. It is true, and it is also a trap, because it answers a question
+nobody asked while hiding the one that matters. The theorem tells you the
+network can match a function. It does not tell you which function you handed it
+to match.
+
+So ask that question instead. When we train a model, what is the function on
+the other side of the equals sign?
+
+## The function we are actually fitting
+
+Look at where the data comes from and the answer is uncomfortable. The text was
+written by people. The labels were drawn by people. The captions, the
+preferences, the thumbs-up and thumbs-down that steer a model after
+pre-training, all of it is human judgment, recorded and replayed. When we
+minimize a loss against that data, the target function the universal
+approximator is reaching for is not "truth" or "intelligence" in the abstract.
+It is *us*. The function is human intelligence, sampled and frozen into a
+dataset, and the network's whole job is to come as close to that function as it
+can.
+
+That reframing should change how the theorem feels. The universal approximator
+is universal in its *means* and entirely bounded in its *target*. It can take
+any shape, but we keep pouring it into the same mold. We have built the most
+flexible function-fitters in history and aimed every one of them at a single
+function: the one that runs in a human head.
+
+## A student cannot pass its teacher by copying
+
+Here is the thing that should bother anyone who wants more than a clever mimic.
+Approximation has a ceiling, and the ceiling is the target. A function fit to
+human judgment converges *toward* human judgment; in the limit of infinite data
+and a perfect optimizer it reaches human judgment and stops. That is not a flaw
+in the network. It is the definition of the task. You cannot exceed a function
+by approximating it. The best possible student of a teacher is a copy of the
+teacher, and a copy does not surpass.
+
+This is why imitation alone was never going to clear the human bar. Every place
+the data is human, the optimum is human. We can make the copy faster, cheaper,
+tireless, able to hold more at once than any person, and those are real and
+enormous advantages. But they are advantages of *scale and speed applied to a
+fixed function*, not a better function. Run a human-level judgment a million
+times a second and you have a very fast human-level judgment. The shape of what
+it knows is still the shape we gave it.
+
+So the interesting question is not "how do we approximate better." We are
+already good at that. The question is what to approximate *instead*. If you want
+a student that surpasses its teacher, you do not give it a better copy of the
+same teacher. You give it a better teacher.
+
+## What is more intelligent than us
+
+Name something that is demonstrably smarter than human cognition and is not
+itself a human artifact, and the list is short. It has exactly one entry.
+
+The universe.
+
+Consider what it does without effort. It folds proteins into their ground state
+in microseconds, a search we throw datacenters at and still get wrong. It
+routes light along the path of least time before any equation is written down.
+It holds a galaxy together and steers an electron through a slit with the same
+small set of laws, and those laws are consistent, compositional, and exact in a
+way no human theory has ever fully matched. The universe is not intelligent in
+the way a person is, with intentions and a voice. It is intelligent in a deeper
+sense: it computes the right answer to staggeringly hard problems, everywhere,
+continuously, and it never contradicts itself. Its laws are the function we have
+been trying to glimpse through the keyhole of human description.
+
+And crucially, that function is *not* bounded by us. Human physics is our best
+approximation of the universe's laws; the laws themselves are the ground truth
+that our physics is the student of. When we fit a model to human knowledge, we
+fit it to the approximation. The universe is the thing the approximation
+approximates. It sits a level below, where the real answers are kept.
+
+## Pointing the approximator at the world
+
+This is where the universal approximation theorem stops being a trap and becomes
+a plan. The network's flexibility was never the problem. The target was. So
+change the target. Train against the universe instead of against the transcript
+of what people have said about it.
+
+We already know what that looks like when it works, because the systems that
+genuinely exceeded human skill did exactly this. The game-playing engines that
+went past every human did not learn from human games; they learned from the
+rules, played against themselves, and let the structure of the game, a tiny
+closed universe with exact laws, be the teacher. The model for protein structure
+surpassed decades of human guessing because its teacher was physical
+plausibility, not the literature. In each case the supervisory signal came from
+a law, not from a person, and the moment that happened the human ceiling lifted,
+because the function being approximated was no longer human.
+
+Generalize the pattern and a research program falls out of it. Build models
+whose loss is grounded in physical law rather than human annotation. Let them
+predict the world and be corrected by the world: by simulation where the
+equations are known, by experiment where they are not, by self-play against a
+reality that does not negotiate. Use human knowledge as the scaffold, the way we
+use a coarse initialization, and then let the universe do the teaching that
+takes the student past the scaffold. The approximator stays the same. We just
+finally point it at the deeper function.
+
+None of this asks the network to be less than human first. It asks us to stop
+*defining* its target as human. The universality was always there, waiting for a
+worthier function to fit. The universe is offering one.
+
+---
+
+Perhaps artificial intelligence's greatest limitation has been our stubborn
+fixation on the human brain as the pinnacle of intelligence. The universe
+itself, governed by elegant and powerful laws, demonstrates intelligence far
+beyond human cognition. These fundamental laws, which shape galaxies and guide
+quantum particles, represent a deeper form of intelligence that we have largely
+ignored in our pursuit of AI.


### PR DESCRIPTION
Adds and publishes a new writeup at `src/content/writeups/the-universe-is-the-better-teacher.mdx`.

The essay argues that the universal approximation theorem makes us universal in *means* but bounded in *target*: we aim every model at one function, human intelligence, and a copy cannot surpass its teacher. To exceed us, train against a teacher that already exceeds us, the universe and its laws. Closes on the user's framing paragraph.

- `draft: false` (published)
- Lives in the `writeups` collection (served at `/blog/writeups/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)