### PR TITLE
Add Run-on-Kaggle links to the three JAX companions

### DIFF
--- a/src/content/blog/mlp-block-is-a-representer-theorem-jax-flax-nnx.mdx
+++ b/src/content/blog/mlp-block-is-a-representer-theorem-jax-flax-nnx.mdx
@@ -34,6 +34,8 @@ import CiteAs from '../../components/CiteAs.astro';
 
 *The [explainer](/blog/mlp-block-is-a-representer-theorem/) argued that a transformer's feed-forward block, with a kernel in place of its activation, becomes a representer-theorem vote: `out(x) = Σ_u k(W_u, x) v_u`, a sum over learned (key, value) slots, the same equation as the attention beside it but over a fixed learned memory. That is not just elegant, it is a **white box**. This companion builds it in Flax NNX, trains it on tinyshakespeare, and then does four things to the FFN that are impossible when it is an opaque slab of ReLU. Every number is from a real run; the script is `scripts/yat_ffn_whitebox.py`.*
 
+*Prefer a notebook? Run the whole thing on [Kaggle](https://www.kaggle.com/code/skywolfmo/a-white-box-ffn-representer-theorem-jax): the same code, block by block, with the math written out, training the transformer live and reproducing every result above (it lands at the same val loss, 1.80).*
+
 ## The feed-forward block, rewritten as a memory
 
 A transformer FFN maps a token's residual vector `x ∈ ℝ^d` to a vector it adds back to the stream, `out(x) = W_2\,\sigma(W_1 x)`. Replace the activation with the [Yat kernel](/blog/what-a-finite-kernel-buys-an-mlp/) and the block stops being a slab. Each row of `W_1` becomes a **key** `W_u`, a prototype direction; each column of `W_2` becomes a **value** `v_u`, a vector written into the residual stream; and the output is a similarity-weighted sum of values:

--- a/src/content/blog/what-can-a-weight-be-jax-flax-nnx.mdx
+++ b/src/content/blog/what-can-a-weight-be-jax-flax-nnx.mdx
@@ -34,6 +34,8 @@ import CiteAs from '../../components/CiteAs.astro';
 
 *The [explainer](/blog/what-can-a-weight-be/) said a kernel is a price list for roughness: its eigenvalues set a cost for every frequency, and the RKHS is the weights you can afford. This is that, in JAX. The eigenvalues are the kernel's spectral density, which a fast Fourier transform hands you for free; the RKHS norm of a weight is a single sum over them; and the same numbers settle, honestly, where the Yat kernel actually lives. Every number is from a real run; the script is `scripts/render_weight_be_gifs.py`.*
 
+*Prefer a notebook? Run the whole thing on [Kaggle](https://www.kaggle.com/code/skywolfmo/what-can-a-weight-be-jax-flax-nnx): the same code, block by block, with the math written out and every figure reproduced from a real run.*
+
 ## A kernel's eigenvalues are its spectral density
 
 On a periodic domain a translation-invariant kernel $k(x, y) = \kappa(x - y)$ is diagonal in the Fourier basis: its eigenfunctions are the modes $\cos(kx), \sin(kx)$, and its eigenvalues $\lambda_k$ are the Fourier transform of $\kappa$. So the whole price list is one FFT.

--- a/src/content/blog/where-does-a-weight-live-jax-flax-nnx.mdx
+++ b/src/content/blog/where-does-a-weight-live-jax-flax-nnx.mdx
@@ -34,6 +34,8 @@ import CiteAs from '../../components/CiteAs.astro';
 
 *The [explainer](/blog/where-does-a-weight-live/) argued that a standard weight is a direction in a space apart from the data, and that a reproducing kernel Hilbert space repairs that by giving the weight an address among the data: the optimal weight is a combination of the data's own kernel bumps. This is the implementation. A kernel in a few lines of JAX, the Gram matrix, one linear solve for the coefficients, and the weight comes out as $\sum_i \alpha_i\, k(x_i, \cdot)$. Then two demonstrations of why the shared space matters. Every number is from a real run; the script is `scripts/render_weight_lives_gifs.py`.*
 
+*Prefer a notebook? Run the whole thing on [Kaggle](https://www.kaggle.com/code/skywolfmo/where-does-a-weight-live-jax-flax-nnx): the same code, block by block, with the math written out and every figure reproduced from a real run.*
+
 ## The kernel, and the space it builds
 
 A reproducing kernel is any positive-definite similarity, and the whole RKHS hangs off it. We use the radial basis kernel, a bump that is largest when two points coincide and decays with their distance. In JAX it is one expression, and it gives the inner product $\langle \phi(x), \phi(y)\rangle$ without ever forming $\phi$.


### PR DESCRIPTION
Each of the three published JAX/Flax NNX companions now links a public, runnable Kaggle notebook that reproduces every result, with the full math and block-by-block code (more extensive than the blog companion):

- [where-does-a-weight-live](https://www.kaggle.com/code/skywolfmo/where-does-a-weight-live-jax-flax-nnx)
- [what-can-a-weight-be](https://www.kaggle.com/code/skywolfmo/what-can-a-weight-be-jax-flax-nnx)
- [a-white-box-ffn-representer-theorem](https://www.kaggle.com/code/skywolfmo/a-white-box-ffn-representer-theorem-jax) (trains the transformer live on Kaggle; lands at the same val loss 1.80)

All three notebooks ran to COMPLETE on Kaggle and reproduced the published figures/numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)