### PR TITLE
Add Run-on-Kaggle links to all remaining JAX companions

### DIFF
--- a/src/content/blog/attention-is-kernel-jax-flax-nnx.mdx
+++ b/src/content/blog/attention-is-kernel-jax-flax-nnx.mdx
@@ -49,6 +49,9 @@ import CiteAs from '../../components/CiteAs.astro';
 
 *The [explainer](/blog/attention-is-a-kernel/) argued that self-attention is a Nadaraya–Watson kernel smoother that has learned its kernel and its targets end-to-end, and that this single fact, not "the matrix is plottable", is what makes attention heads readable. This is the implementation companion: build attention from scratch in [Flax NNX](https://flax.readthedocs.io/en/latest/api_reference/flax.nnx/module.html), turn each prose claim into an `assert`, and watch the one caveat (the kernel is not symmetric, so not Mercer in the strict sense) fall out of the numbers. The dimensions are tiny so every array is legible.*
 
+*Prefer a notebook? Run the whole thing on [Kaggle](https://www.kaggle.com/code/skywolfmo/attention-is-a-kernel-jax-flax-nnx): the same code, block by block, with the math written out and every figure reproduced from a real run.*
+
+
 ## Scaled dot-product attention, by hand
 
 A single attention head is three learned projections and a softmax. In `nnx.Linear` the kernel maps the last axis, so the module reads the same whether `x` is one token or a sequence.

--- a/src/content/blog/convex-readout-jax-flax-nnx.mdx
+++ b/src/content/blog/convex-readout-jax-flax-nnx.mdx
@@ -34,6 +34,9 @@ import CiteAs from '../../components/CiteAs.astro';
 
 *The [explainer](/blog/readout-as-convex-combination/) reframed the MLP readout $W_\text{out}\,a(x)=\sum_u a_u(x)\,r_u$ as a mixture over output prototypes, whose geometry (convex, conic, affine, or linear) is set by two constraints on the coefficients: are they nonnegative, and do they sum to one? This is the implementation companion: pull the prototypes out of an NNX `Linear`, measure which regime each activation lands in, and build a kernel readout that is convex by construction, with the correctness checks that the explainer's claims rest on written as `assert`s.*
 
+*Prefer a notebook? Run the whole thing on [Kaggle](https://www.kaggle.com/code/skywolfmo/the-readout-as-a-convex-combination-jax): the same code, block by block, with the math written out and every figure reproduced from a real run.*
+
+
 <figure class="jax-fig jax-fig-wide">
   <img src="/blog/convex-readout-field.gif" alt="Animated kernel readout: a query roams the input space while the readout traces the interior of the output prototype hull" loading="eager" width="1100" height="560" />
   <figcaption>The kernel readout, computed in JAX. As the query $x$ roams the input space (left), its normalized Gaussian similarities to the input prototypes become convex coefficients that mix the output prototypes (right). The readout $y=\sum_u a_u r_u$ traces the interior of the output hull and never leaves it, because $\sum_u a_u = 1$ with every $a_u \ge 0$ by construction, not by a check after the fact.</figcaption>

--- a/src/content/blog/edit-a-network-jax-flax-nnx.mdx
+++ b/src/content/blog/edit-a-network-jax-flax-nnx.mdx
@@ -36,6 +36,9 @@ import CiteAs from '../../components/CiteAs.astro';
 
 *The [explainer](/blog/edit-a-network-by-hand/) argued that a Yat-kernel network is a list of prototype pictures, so you can teach it a class by adding pictures and make it forget one by deleting them, with no training. This is the implementation: build the network in [Flax NNX](https://flax.readthedocs.io/en/latest/api_reference/flax.nnx/module.html), then watch teaching reduce to a `jnp.concatenate` and forgetting to a boolean mask. Every figure and number below is from a real run; the script is `scripts/yat_editable_fmnist.py`.*
 
+*Prefer a notebook? Run the whole thing on [Kaggle](https://www.kaggle.com/code/skywolfmo/edit-a-network-by-hand-jax-flax-nnx): the same code, block by block, with the math written out and every figure reproduced from a real run.*
+
+
 ## The layer, and what its rows are
 
 If teaching and forgetting are going to be array edits, the array has to be shaped for it: one prototype to a row, and nothing about a class smeared anywhere else. A Yat unit scores an input against a prototype $W_u$ with the kernel $(W_u^\top x + b)^2 / (\lVert x - W_u\rVert^2 + \varepsilon)$, a layer is a bank of them, and the readout lets each prototype vote for a class. The prototypes are the rows of `W`, each row's vote a row of the readout, and editing the network will turn out to be nothing more than editing those rows.

--- a/src/content/blog/handbuilt-features-jax-flax-nnx.mdx
+++ b/src/content/blog/handbuilt-features-jax-flax-nnx.mdx
@@ -35,6 +35,9 @@ import CiteAs from '../../components/CiteAs.astro';
 
 *The [explainer](/blog/you-dont-have-to-train-the-features/) argued that you can build a whole image classifier by hand, features and all, and still reach 83.3% on Fashion-MNIST with nothing trained. This is the implementation. The feature extractor is pure JAX, a few lines of gradient and pooling; the classifier is a [Flax NNX](https://flax.readthedocs.io/en/latest/api_reference/flax.nnx/module.html) module that holds k-means prototypes and votes with the Yat kernel. There is no training loop in this post, because there is nothing to train. Every number is from a real run; the script is `scripts/jax_handbuilt.py`.*
 
+*Prefer a notebook? Run the whole thing on [Kaggle](https://www.kaggle.com/code/skywolfmo/you-dont-have-to-train-the-features-jax-flax-nnx): the same code, block by block, with the math written out and every figure reproduced from a real run.*
+
+
 ## The detectors, as a convolution
 
 A hand-built feature starts as a gradient. Two Sobel kernels give the horizontal and vertical derivative of the image, and from those come the magnitude and angle of every edge. The only subtlety is the padding: we replicate the border (`mode='edge'`) so an edge at the image boundary is not invented out of zeros.

--- a/src/content/blog/latent-on-the-spectrum-jax.mdx
+++ b/src/content/blog/latent-on-the-spectrum-jax.mdx
@@ -42,6 +42,9 @@ import CiteAs from '../../components/CiteAs.astro';
 
 *The [explainer](/blog/latent-on-the-spectrum/) reframed a codebook as the spectral embedding of a label-similarity kernel: diagonalise the kernel, keep its strongest modes, and the geometry follows the spectrum. This is the implementation companion: the classical-MDS embedding in JAX (with the square-root scaling done right), the flat→simplex and graded→horseshoe morph, kernel-target alignment, and the split of a trained representation into its prototype frame and its information spectrum, all as runnable `jnp.linalg.eigh`.*
 
+*Prefer a notebook? Run the whole thing on [Kaggle](https://www.kaggle.com/code/skywolfmo/latent-on-the-spectrum-jax): the same code, block by block, with the math written out and every figure reproduced from a real run.*
+
+
 <figure class="jax-fig jax-fig-wide">
   <img src="/blog/spectral-codebook.gif" alt="Animated spectral embedding of a label kernel morphing from an even ring to a horseshoe as the kernel spectrum goes from flat to peaked" loading="eager" width="1100" height="520" />
   <figcaption>A codebook is the spectral embedding of a label kernel, computed live in JAX. As the kernel goes from flat (structureless) to graded (similarity falls off with class distance), its eigenspectrum peaks and the top two modes morph the codebook from an even ring (the simplex) into the horseshoe of classical MDS. The embedding and the spectrum are both `jnp.linalg.eigh`.</figcaption>

--- a/src/content/blog/linear-attention-jax-flax-nnx.mdx
+++ b/src/content/blog/linear-attention-jax-flax-nnx.mdx
@@ -32,6 +32,9 @@ import CiteAs from '../../components/CiteAs.astro';
 
 *The theory post argued that cheap attention is not a separate trick from attention. It is the same kernel sum, evaluated through a finite feature map and parenthesized in the useful order. This is the implementation companion: the JAX arrays, the Flax NNX module, the causal recurrence, and the GIFs that show the bookkeeping changing from an all-pairs ledger to a shared state.*
 
+*Prefer a notebook? Run the whole thing on [Kaggle](https://www.kaggle.com/code/skywolfmo/cheap-attention-is-linear-attention-jax): the same code, block by block, with the math written out and every figure reproduced from a real run.*
+
+
 <figure class="jax-fig jax-fig-wide">
   <img src="/blog/gravity-attention-bookkeeping.gif" alt="Animated comparison of gravity and attention: all-pairs ledgers versus shared fields or feature states, with compute bars for each side" loading="eager" width="1280" height="720" />
   <figcaption>The analogy in one GIF. Gravity has a direct N-body ledger and a field solve. Attention has exact softmax pair scores and a feature-state approximation. The details differ; the bookkeeping shape is the same.</figcaption>

--- a/src/content/blog/organizing-randomness-jax.mdx
+++ b/src/content/blog/organizing-randomness-jax.mdx
@@ -66,6 +66,9 @@ import CiteAs from '../../components/CiteAs.astro';
 
 *The runnable companion to [Untangling the Moons](/blog/untangling-the-moons/). There I raced the losses; here I build them.*
 
+*Prefer a notebook? Run the whole thing on [Kaggle](https://www.kaggle.com/code/skywolfmo/untangling-the-moons-jax): the same code, block by block, with the math written out and every figure reproduced from a real run.*
+
+
 <figure class="jax-fig jax-fig-wide">
   <img src="/blog/jax-contrastive/grid-six.gif" alt="Six contrastive losses organizing the same random 2D points side by side: pair, triplet, InfoNCE, SupCon, SigLIP, cosine-to-zero" loading="eager" width="900" height="600" />
   <figcaption>Where we're headed: six contrastive losses, the same random start, the same step counter. Every loss below is the ~15 lines of JAX that produces one of these panels. (Full walkthrough in <a href="#the-race">the race</a>.)</figcaption>

--- a/src/content/blog/qk-projections-jax-flax-nnx.mdx
+++ b/src/content/blog/qk-projections-jax-flax-nnx.mdx
@@ -40,6 +40,9 @@ import CiteAs from '../../components/CiteAs.astro';
 
 *The [explainer](/blog/why-attention-needs-qk-projections/) argued that $Q$ and $K$ projections turn a dot product into a learned, low-rank, role-aware bilinear form $s_{ij}=x_i^\top W_Q W_K^\top x_j$. This is the implementation companion: the Flax NNX attention module, the bilinear form pulled back out of it, its symmetric/antisymmetric split, a toy induction head, RoPE, and the two facts about the factorization you can check with a single `assert`: the rank budget and the gauge freedom.*
 
+*Prefer a notebook? Run the whole thing on [Kaggle](https://www.kaggle.com/code/skywolfmo/why-attention-needs-qk-projections-jax): the same code, block by block, with the math written out and every figure reproduced from a real run.*
+
+
 <figure class="jax-fig jax-fig-wide">
   <img src="/blog/qk-bilinear-decomp.gif" alt="Animated decomposition of a bilinear score matrix into a symmetric metric part and an antisymmetric directed part, with the diagonal held fixed" loading="eager" width="1100" height="540" />
   <figcaption>The whole post in one loop, computed in JAX. A head's score is $s_{ij}=x_i^\top B\,x_j$ with $B = S + A$: a symmetric metric $S$ plus an antisymmetric directed part $A$. Dial $\alpha$ and the total score matrix slides from symmetric to visibly asymmetric, while the boxed diagonal (the self-scores) never moves, because $x^\top B x = x^\top S x$. Directionality is the off-diagonal part, and it is exactly what separate $Q$ and $K$ buy.</figcaption>

--- a/src/content/blog/three-states-of-information-jax.mdx
+++ b/src/content/blog/three-states-of-information-jax.mdx
@@ -48,6 +48,9 @@ import CiteAs from '../../components/CiteAs.astro';
 
 *The [explainer](/blog/three-states-of-information/) named three states a representation passes through while training (**random**, **organized**, **structured**) and argued the loss plateaus are the transitions between them. This is the implementation companion: four tiny JAX runs that **measure** each state directly. The spectrum's effective rank falling from `d` toward `C−1`; the simplicity bias that fits a near-linear boundary before it wraps the moons; the class-mean cosines locking onto the Welch value `−1/(C−1)`; and the contrastive loss splitting into two forces on two clocks. Each metric is an eigenvalue or a loss, nothing scripted.*
 
+*Prefer a notebook? Run the whole thing on [Kaggle](https://www.kaggle.com/code/skywolfmo/three-states-of-information-jax): the same code, block by block, with the math written out and every figure reproduced from a real run.*
+
+
 Everything below is plain JAX on tiny synthetic data (a few hundred points, a two-layer MLP), so the training loop and the linear algebra both fit on screen. A shared step function does the work:
 
 ```python

--- a/src/content/blog/train-the-features-jax-flax-nnx.mdx
+++ b/src/content/blog/train-the-features-jax-flax-nnx.mdx
@@ -35,6 +35,9 @@ import CiteAs from '../../components/CiteAs.astro';
 
 *The [explainer](/blog/train-the-features/) split a network into a backbone that builds features and a head that classifies, trained only the backbone, and built the head by hand. This is the implementation in JAX. The backbone is a small [Flax NNX](https://flax.readthedocs.io/en/latest/api_reference/flax.nnx/module.html) convolutional network with a normal training loop; the head is a constructed Yat vote placed on the frozen features, with no gradient steps. The whole point is to run both and see how little the head needs. Every number is from a real run; the script is `scripts/jax_train_features.py`.*
 
+*Prefer a notebook? Run the whole thing on [Kaggle](https://www.kaggle.com/code/skywolfmo/train-the-features-jax-flax-nnx): the same code, block by block, with the math written out and every figure reproduced from a real run.*
+
+
 ## The two stages, as two modules
 
 A network is a backbone and a head. The backbone is the part we train, two conv-and-pool blocks down to a 64-dimensional feature; the head is a plain linear layer for the trained baseline, and later a placed Yat vote for the constructed version.

--- a/src/content/blog/welch-bound-jax-analysis.mdx
+++ b/src/content/blog/welch-bound-jax-analysis.mdx
@@ -36,6 +36,9 @@ import CiteAs from '../../components/CiteAs.astro';
 
 *The runnable companion to [What Makes a Good Latent Space?](/blog/welch-bound-good-latent-space/). There I argued that a good latent space is a low-crosstalk codebook. Here we build the audit in JAX and render the same geometry as GIFs.*
 
+*Prefer a notebook? Run the whole thing on [Kaggle](https://www.kaggle.com/code/skywolfmo/the-welch-bound-and-a-good-latent-space-jax): the same code, block by block, with the math written out and every figure reproduced from a real run.*
+
+
 The point of the theory post was not "the Welch bound is cool." The useful
 claim was operational:
 

--- a/src/content/blog/yat-mlp-fmnist-jax-flax-nnx.mdx
+++ b/src/content/blog/yat-mlp-fmnist-jax-flax-nnx.mdx
@@ -35,6 +35,9 @@ import CiteAs from '../../components/CiteAs.astro';
 
 *The [explainer](/blog/your-neuron-is-a-picture/) argued that a neuron storing a direction can never be pointed at, while a neuron storing a prototype is a thing you can look at, and on images that thing is a picture. This is the implementation companion: build the prototype MLP in [Flax NNX](https://flax.readthedocs.io/en/latest/api_reference/flax.nnx/module.html), train it on Fashion-MNIST, and then actually look at the neurons. Every figure and number below is from a real run.*
 
+*Prefer a notebook? Run the whole thing on [Kaggle](https://www.kaggle.com/code/skywolfmo/your-neuron-is-a-picture-jax-flax-nnx): the same code, block by block, with the math written out and every figure reproduced from a real run.*
+
+
 ## The network, with no activation function
 
 Everything the explainer promised has to survive contact with code, and the first surprise is how little code there is. The network has no activation function anywhere in it. A Yat unit measures the input against a learned prototype $W_u$ with the kernel $(W_u^\top x + b)^2 / (\lVert x - W_u\rVert^2 + \varepsilon)$, a layer is a bank of them, and that layer plus a linear readout is the whole model.

--- a/src/content/blog/yat-mlp-jax-flax-nnx.mdx
+++ b/src/content/blog/yat-mlp-jax-flax-nnx.mdx
@@ -42,6 +42,9 @@ import CiteAs from '../../components/CiteAs.astro';
 
 *The [explainer](/blog/what-a-finite-kernel-buys-an-mlp/) argued that if you put a finite, positive-definite kernel where the activation function used to be, an MLP stops being a stack of linear maps glued by a nonlinearity and becomes a kernel machine, with locality, attribution, geometry, capacity control, and a feature map you can write down. This is the implementation companion: build that layer in [Flax NNX](https://flax.readthedocs.io/en/latest/api_reference/flax.nnx/module.html), turn each claim into an `assert`, and train the thing end to end. Every number and figure below is from a real run. The dimensions are tiny so the objects are legible.*
 
+*Prefer a notebook? Run the whole thing on [Kaggle](https://www.kaggle.com/code/skywolfmo/what-a-finite-kernel-buys-an-mlp-jax-flax-nnx): the same code, block by block, with the math written out and every figure reproduced from a real run.*
+
+
 <figure class="jax-fig jax-fig-wide">
   <img src="/blog/yat-vs-relu-mlp.gif" alt="Two MLPs learning the same two-moons data side by side: a ReLU MLP with a piecewise-linear boundary, and a Yat-kernel MLP with a smooth boundary and visible prototype rings" loading="eager" width="1100" height="540" />
   <figcaption>The whole point in one picture, trained live in JAX. Same two-moons data, two units. Left: a standard Linear→ReLU→Linear MLP, a bank of directions whose boundary is piecewise-linear and runs off to infinity. Right: the Yat-kernel MLP, a bank of prototypes (the rings, readable as centres in input space), whose boundary wraps the data, with no activation function anywhere. Both reach 100%; the difference is the geometry.</figcaption>


### PR DESCRIPTION
Every JAX companion now links a public, runnable Kaggle notebook (full math + block-by-block code + faithful figures with animated GIFs shown inline). 13 companions linked here (the other 3 were linked earlier). All notebooks authored from the companions' real scripts and verified to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)