### PR TITLE
Publish San Francisco writeup: dreams, delulu, and the messiah syndrome

### DIFF
--- a/src/content/writeups/san-francisco-dreams-delulu-messiah.mdx
+++ b/src/content/writeups/san-francisco-dreams-delulu-messiah.mdx
@@ -1,0 +1,125 @@
+---
+title: "San Francisco: The Dreams, the Delulu, and the Messiah Syndrome"
+description: "A love letter and an indictment. The city runs on three fuels at once: genuine dreams, collective delusion, and the quiet conviction that you, personally, were sent to save the world."
+seoDescription: "San Francisco runs on three fuels at once: genuine dreams, collective delusion, and the founder's conviction that he was sent to save the world."
+pubDate: 2026-07-01
+tags: [notes, san-francisco, tech, ai, culture]
+draft: false
+---
+
+There is a particular look people get when they land in San Francisco for the
+first time to build something. I have worn it myself. It is the look of someone
+who has finally arrived at the place where the future is manufactured, who has
+been told their whole life that the thing they want is impossible, and who has
+just walked into the one city on earth where "impossible" is a pitch, not a
+verdict. It is a beautiful look. It is also the first symptom.
+
+Because the city runs on three fuels at once, and from the inside they are almost
+impossible to tell apart. There is the dream, which is real. There is the delulu,
+which is what the dream turns into when it stops checking itself against the
+world. And there is the messiah syndrome, which is what happens when the delulu
+learns to talk about humanity.
+
+## The dreams are real, and that is the trap
+
+Start with the part that is true, because it is the part that makes the rest so
+hard to see.
+
+San Francisco is the densest concentration of ambition I have ever stood in. You
+sit down at a coffee shop and the two people next to you are arguing about
+mechanistic interpretability, and the two on the other side are wiring up a
+protein-folding pipeline, and none of them are famous, and all of them are
+serious. The ambient belief that you can just *build the thing* is not a slogan
+here. It is the water. People move across oceans, leave families, blow up
+careers, and sleep on someone's couch for the privilege of being near it. I did
+a version of this. I do not regret it.
+
+And it works, sometimes, spectacularly. The dreams that came true in this small
+peninsula rewired how the entire planet talks, searches, moves money, and now
+thinks. That is not delusion. That is the receipts. The reason the delusion is so
+contagious is that the dream keeps *cashing*. If the city produced nothing, no
+one would fall for it. It is precisely because a handful of the impossible things
+became ordinary that the next thousand impossible pitches get a hearing.
+
+So the trap is not that the dreams are fake. The trap is that they are real often
+enough to make you stop asking which is which.
+
+## The delulu is the dream with the feedback loop cut
+
+Here is the question that separates the two. When your idea meets the world, does
+the world get a vote?
+
+A dream keeps a wire running back to reality. It ships, it watches, it lets the
+numbers hurt. The delulu cuts that wire. It replaces the world's verdict with the
+room's applause, and in San Francisco the room is always, always applauding. The
+whole social machinery is tuned to say yes. The investor is long optionality, so
+he nods. The other founders need you to believe, because your belief underwrites
+theirs. The conference gives you a stage. The timeline hands you a thousand
+strangers who will call a landing page "insane" and mean it as praise. Nobody in
+the building is incentivized to tell you the thing does not work.
+
+And so a very specific dialect grows. Every tool is a *revolution*. Every app is
+*changing the world*. A company that lets people rent scooters is on a *mission
+to reshape human mobility*. The language inflates to fill the space where a real
+signal used to be, because when reality stops answering, you have to generate the
+sense of significance yourself. That is what the delulu is: not lying, exactly,
+but running the significance meter off an internal battery because you unplugged
+it from the wall.
+
+The tell is always the same. The delulu cannot be disappointed. Bad numbers
+become "we are early." A dead launch becomes "the market is not ready." The wire
+to the world is cut, so no piece of evidence can ever get back in to correct the
+story. A dream can be killed by a fact. A delusion has made itself unkillable,
+and it wears that as a virtue. Conviction, it calls it. Resilience.
+
+## The messiah syndrome is the delulu that learned to say "humanity"
+
+There is a final stage, and it is the one I find genuinely dangerous, because it
+recruits the best instincts a person has and turns them into armor.
+
+At some point the story stops being about the product and starts being about the
+world being *saved*, and about the specific role you play in saving it. You are
+not building a company. You are *the only one who can see it*. You are not
+shipping a model. You are carrying humanity across a threshold, and the people
+who doubt you are not skeptics with a point, they are obstacles to the future.
+The mission gets so large that no ordinary evidence is allowed to touch it,
+because how dare a mere quarterly number question the salvation of the species.
+
+I want to be careful here, because I work in a field that has more reason than
+most to think in these terms. Some of the things being built genuinely do
+operate at the scale of everyone. That is exactly why the syndrome is so
+seductive in AI specifically: the stakes are real enough that the grandiosity
+does not feel like grandiosity. It feels like *responsibility*. And the move it
+performs is subtle. It takes "this could matter enormously," which is a humble
+and frightening thought, and quietly rewrites it into "and therefore I, the one
+building it, am enormously important," which is a completely different claim
+wearing the first one's clothes.
+
+The messiah syndrome is what you get when the delusion figures out that the word
+"humanity" makes it unfalsifiable. You cannot argue with a savior. Every
+critique becomes proof of the critic's smallness. Every check on power becomes an
+attack on the mission. The scariest sentence in this city is not "we will fail."
+It is "we will figure out the ethics later, we are too important to slow down
+now." I have heard it in a dozen accents. I have caught it forming in my own
+mouth.
+
+## Which one am I running on
+
+I am not writing this from above it. I moved toward this world on purpose. I have
+worn the arriving-founder look, inflated a description past what the numbers
+earned, and felt the warm pull of a mission large enough to excuse me from
+ordinary accountability. The three fuels are not three kinds of people. They are
+three settings on the same engine, and the engine is in me too.
+
+So I have stopped trying to be pure of it and started trying to keep one thing
+alive instead: the wire. The line back to the world that gets a vote. Did the
+thing actually work, for someone who is not paid to say yes. Would I still
+believe this if the room went quiet. Is the mission doing intellectual labor, or
+is it just making me feel important enough to skip the labor.
+
+Keep that wire connected and the dream stays a dream. Cut it and you will not
+notice the moment you cross into the other two, because from the inside all three
+feel exactly like faith. San Francisco will never tell you which one you are on.
+That was never its job. It just hands you the fuel and points you at the future,
+and it is on you, every single morning, to check whether you are still plugged
+into anything real.


### PR DESCRIPTION
Publishes a new personal writeup on San Francisco: the dreams, the delulu, and the messiah syndrome. Lives in the writeups collection (separate from the AI-theory blog). draft: false.