### PR TITLE
Generation Zero: sharpen the professor passage

### DIFF
--- a/src/content/writeups/generation-zero.mdx
+++ b/src/content/writeups/generation-zero.mdx
@@ -224,10 +224,15 @@ under my name, and be grateful, because that is better for your future than
 the country that would actually fund you. If you want to keep someone, there
 is a minimum, and it is not even generosity, it is infrastructure: an
 environment where they can work and pay so they can live while they do it.
-The offer contained neither. The only resource in it was me. And he meant
-well, or believed he did, which took me years to understand is not a defense.
-It is the mechanism. The people who ask you to shrink almost always mean
-well, because meaning well is what lets them ask.
+The offer contained neither. The only resource in it was me. For a long time I
+told myself he meant well, because that was the more comfortable story. He did
+not. What he saw was an asset: me, and the years of unfunded work I would keep
+pouring into a foundation he would sit on top of. Keep me in Morocco, on my own
+dime, building the lab and the results and the standing, and he would be the
+name attached when the funding those things attract finally arrived. My future
+was not what he was protecting; it was what he was harvesting. The warmth was
+never the motive, it was the wrapping. "Better for your future" is what "better
+for mine" learns to say when it needs you to agree to it.
 
 I have since learned the test, and it is the same test I use for praise and
 for paperwork: what does this cost them? An opportunity that costs the offerer


### PR DESCRIPTION
Corrects the professor/extortion passage: the offer to stay in Morocco was self-interest (harvesting unfunded work as a foundation to draw funding from), not good faith. One-paragraph edit to the live essay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)