### PR TITLE
Generation Zero: take responsibility in 'Was it me?'

### DIFF
--- a/src/content/writeups/generation-zero.mdx
+++ b/src/content/writeups/generation-zero.mdx
@@ -255,26 +255,35 @@ the audacity unthinkable? A person with boundaries does not get asked to hand
 over his future, the theory goes, so if I kept getting asked, the missing
 boundary must have been mine.
 
-I lived inside that theory for years, and it is wrong, and the reason it is
-wrong is invisible from the inside. A boundary is not a sentence you say. It is
-a sentence you can afford to mean. "No" only has teeth if you can walk, and
-walking requires somewhere else to stand. The person born on the shoulders has a
-dozen somewhere-elses: another lab, another offer, a family that floats him
-through the gap, a name that opens the next door before this one shuts. His no
-costs him nothing, so it holds, and he mistakes the holding for character.
-Generation zero has no somewhere-else. When the one door in front of me was also
-the only door I could see, "no" did not cost me a principle, it cost me the
-year, the work, the path, sometimes the rent. A boundary you cannot afford to
-enforce is not a boundary, it is a bluff, and the people who make these offers
-are expert readers of bluffs. They were not testing my character. They had
-already priced my lack of alternatives, and the audacity was calibrated to it
-exactly.
+Some of it was me, and I want to name that part first, because an essay that
+puts the whole thing on the rooms is a flattering lie, and I did not get this
+far by telling myself flattering lies. I wanted to be chosen badly enough that
+I let a person's interest in my work feel like belief in me, which it never
+was. I overvalued every door because I had built no others, and a man with one
+door will agree to almost anything to keep it from shutting. I saw the early
+signs more than once and argued myself out of them, because asking the blunt
+question felt like ingratitude, and some part of me would rather have been used
+than be the one who counted the furniture at the wedding. None of that is the
+position. That is character, and the account was mine.
 
-So the missing boundary was not a flaw in me. It was a feature of the position.
-You cannot draw a line you have no power to hold, and having that power is a
-privilege I did not start with. That sounds like the end of the thought, an
-excuse even, until you turn it over and find the whole usable lesson on the
-other side.
+It is also true, and this is the part it took me years to separate from an
+excuse, that a boundary is not a sentence you say, it is a sentence you can
+afford to mean. A no only has teeth if you can walk, and walking needs
+somewhere else to stand. The person born on the shoulders has a dozen
+somewhere-elses, another lab, another offer, a family that floats him through
+the gap, and his no costs him nothing, so it holds, and he mistakes the holding
+for character the same way I once mistook my lack of options for a defect in
+mine. My position made the mistake cheaper to make and far more expensive to
+refuse. But that explains why I kept walking into the same room. It does not
+undo the walking. Structure is an explanation, and a real one. It is never an
+alibi.
+
+So the honest answer to the question is yes, partly, in exactly the part that
+was mine to change. And once you say it that way, the argument about whose
+fault it was stops being the interesting one, because both sides point at the
+same move. The position says build an alternative so that a no costs you less.
+The character says build an alternative so that you stop needing to be chosen.
+Same instruction, and it was mine to carry out.
 
 ## What to do when you cannot afford to lose
 
@@ -296,10 +305,10 @@ while it is still cheap and still feels rude to ask, because the only person it
 burns is the one whose plan needed it un-asked. Run every warm offer through the
 test that has never failed me: what does this cost the person offering it? An
 opportunity that costs them nothing and you everything is not an opportunity, no
-matter how much it says it loves you. And stop auditing yourself for other
-people's nerve. Their behavior is information about them; it is not a verdict on
-your posture. You did not consent to being taken from by being takeable, any
-more than a house consents to the burglar by having a door.
+matter how much it says it loves you. And once you have squarely owned
+your share, stop paying rent on theirs. Another person's nerve is information
+about them; it is not the rest of the verdict on you. Owning what was yours and
+refusing what was never yours are the same discipline, not opposite ones.
 
 None of this is armor, and I am not selling armor. The openness is the thing
 that made my work worth taking in the first place, and I would not close up even


### PR DESCRIPTION
Rewrites the boundary-privilege section so it owns the author's real share first and treats the structural insight as explanation, not excuse. No blame-shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)