### PR TITLE
Transparency colophon on every post

### DIFF
--- a/src/components/Colophon.astro
+++ b/src/components/Colophon.astro
@@ -1,0 +1,32 @@
+---
+// A standing transparency note rendered at the foot of every post. The ideas,
+// claims, and mistakes are the author's; the wording is worked out in dialogue
+// with an AI, because the author thinks in math and images more than in words.
+---
+<aside class="colophon" aria-label="How this was written">
+  <p>
+    A note on how this is written. I think mostly in mathematics, pictures, and
+    intuition, and much less in words. So I reason many of these ideas out in
+    conversation with an AI and lean on it to turn the thinking into language.
+    Some of these pieces, the essays especially, began as exactly those
+    discourses about life and math. The reasoning, the claims, and the mistakes
+    are mine; the help is in the wording. I would rather tell you that plainly
+    than pretend the sentences arrived on their own.
+  </p>
+</aside>
+
+<style>
+  .colophon {
+    margin: 2.5rem 0 0;
+    padding: 0.9rem 1.1rem;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg-sunken, var(--bg));
+  }
+  .colophon p {
+    margin: 0;
+    font-size: 0.82rem;
+    line-height: 1.6;
+    color: var(--fg-muted);
+  }
+</style>

--- a/src/content/writeups/why-writeups.mdx
+++ b/src/content/writeups/why-writeups.mdx
@@ -26,5 +26,17 @@ Some of what lives here is older than any of the proofs. There is a poem from
 keep them in the same room on purpose, because they are who was writing before
 the theorems showed up.
 
+One more thing, because it would be dishonest to leave it unsaid. I do not
+think in words. I think in mathematics, in pictures, in a kind of wordless
+intuition that I then have to translate for anyone who is not inside my head,
+including, often, myself. So the way many of these pieces come into being is a
+long discourse with an AI, where I reason out loud about life or about math and
+use it to find the language my own head does not hand me. Some of the essays
+here started as exactly that conversation. The thoughts are mine, the shape of
+the argument is mine, and every mistake is mine to own; what the machine lends
+me is the wording. I would rather tell you that at the door than let you assume
+the sentences grew on their own, because the one thing this corner cannot
+afford is to lie to you about how it is made.
+
 So, two doors. The other one tells you whether the work holds. This one tells
 you what it cost, and I am the only one who can be caught lying about that.

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -8,6 +8,7 @@ import RelatedPosts from '../components/RelatedPosts.astro';
 import CompanionCallout from '../components/CompanionCallout.astro';
 import SeriesNav from '../components/SeriesNav.astro';
 import References from '../components/References.astro';
+import Colophon from '../components/Colophon.astro';
 import PostAnalytics from '../components/PostAnalytics.astro';
 
 interface NavItem { slug: string; title: string }
@@ -99,6 +100,7 @@ const postSlug = base && postPath.startsWith(`${base}/`)
     {pair && <CompanionCallout pair={pair} />}
     <slot />
     <References items={references} />
+    <Colophon />
   </article>
   <PostAnalytics
     title={title}

--- a/src/layouts/WriteupLayout.astro
+++ b/src/layouts/WriteupLayout.astro
@@ -2,6 +2,7 @@
 import BaseLayout from './BaseLayout.astro';
 import Giscus from '../components/Giscus.astro';
 import CodeCopy from '../components/CodeCopy.astro';
+import Colophon from '../components/Colophon.astro';
 import ReadingProgress from '../components/ReadingProgress.astro';
 
 // Standalone layout for the personal `writeups` collection. Intentionally lean
@@ -64,6 +65,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
       )}
     </header>
     <slot />
+    <Colophon />
     <p class="back-link"><a href={`${base}/writeups/`}>← all writeups</a></p>
   </article>
   <Giscus />


### PR DESCRIPTION
Adds an honest standing note (Colophon component in both layouts + a fuller paragraph in the writeups manifesto): the reasoning and claims are the author's, worked out in dialogue with an AI that supplies the wording, because the author thinks non-verbally. Some essays began as those discourses about life and math.

🤖 Generated with [Claude Code](https://claude.com/claude-code)