### PR TITLE
Call them writeups and stories, not essays

### DIFF
--- a/src/components/Colophon.astro
+++ b/src/components/Colophon.astro
@@ -8,7 +8,7 @@
     A note on how this is written. I think mostly in mathematics, pictures, and
     intuition, and much less in words. So I reason many of these ideas out in
     conversation with an AI and lean on it to turn the thinking into language.
-    Some of these pieces, the essays especially, began as exactly those
+    Some of these pieces, the stories especially, began as exactly those
     discourses about life and math. The reasoning, the claims, and the mistakes
     are mine; the help is in the wording. I would rather tell you that plainly
     than pretend the sentences arrived on their own.

--- a/src/content/writeups/generation-zero.mdx
+++ b/src/content/writeups/generation-zero.mdx
@@ -129,7 +129,7 @@ one sentence's worth of belief, and she spent all of it on me.
 
 ## The ones who were smarter, and the rooms we sat in
 
-Here is the part I actually wrote this essay for.
+Here is the part I actually wrote this story for.
 
 I was not the smartest person in those classrooms. I was smart, there is no
 point being coy about it, but there were always others as sharp or sharper in
@@ -255,7 +255,7 @@ the audacity unthinkable? A person with boundaries does not get asked to hand
 over his future, the theory goes, so if I kept getting asked, the missing
 boundary must have been mine.
 
-Some of it was me, and I want to name that part first, because an essay that
+Some of it was me, and I want to name that part first, because a story that
 puts the whole thing on the rooms is a flattering lie, and I did not get this
 far by telling myself flattering lies. I wanted to be chosen badly enough that
 I let a person's interest in my work feel like belief in me, which it never
@@ -289,7 +289,7 @@ Same instruction, and it was mine to carry out.
 
 Because if the boundary follows from the alternative, then the move is not to be
 braver in the room. It is to build the alternative before you ever walk into it.
-This is the one thing in this essay I would put directly into the hands of
+This is the one thing in this writeup I would put directly into the hands of
 someone still inside the maze, and it is not "stand your ground," which is
 advice for people who already own ground. It is: manufacture a second door, on
 purpose, before you need it. Keep the other application alive. Keep the other

--- a/src/content/writeups/i-already-failed-at-football.mdx
+++ b/src/content/writeups/i-already-failed-at-football.mdx
@@ -135,8 +135,8 @@ installed, and it still delivers, faithfully, to my first address. Until I
 finish amending it, I will keep mailing my trophies to a house I no longer
 live in.
 
-Which leaves a question I cannot close this essay without noticing, because
-the whole essay has quietly been sharpening it. If the wins do not pay, and
+Which leaves a question I cannot close this writeup without noticing, because
+the whole story has quietly been sharpening it. If the wins do not pay, and
 the fear does not push, then the two engines that drive most people are both
 unplugged in me, and yet I have worked for years, past every stop sign, at
 full throttle, on things nobody around me asked for. Something is running.
@@ -144,4 +144,4 @@ Something got a boy through school no one believed in, across an ocean, into
 fields that did not exist in the room that raised him, and it was not the
 hope of a trophy and it was not the whip of a deadline. So what keeps me
 motivated? I have an answer, or at least I have caught the thing moving and
-taken notes. That is the next essay.
+taken notes. That is the next writeup.

--- a/src/content/writeups/why-writeups.mdx
+++ b/src/content/writeups/why-writeups.mdx
@@ -1,6 +1,6 @@
 ---
 title: Why a separate corner for writeups
-description: "The blog is where I prove things, and the payment is a plot. This corner is where I confess things, and the payment is skin. A front door for the essays, the field notes, and the poem."
+description: "The blog is where I prove things, and the payment is a plot. This corner is where I confess things, and the payment is skin. A front door for the writeups, the stories, the field notes, and the poem."
 pubDate: 2026-06-15
 tags: [meta, notes]
 draft: false
@@ -18,11 +18,11 @@ importance. Which of my failures I can trace by hand. The payment is skin.
 I used to introduce these pieces as less finished than the theory, and that
 was a lie I told to lower the stakes. They are not less finished. They are
 differently accountable. A theory post answers to a benchmark that does not
-care about me. An essay here answers to my own record, which knows exactly
+care about me. A writeup here answers to my own record, which knows exactly
 where I am flattering myself. Of the two audits, the second is harder to pass.
 
 Some of what lives here is older than any of the proofs. There is a poem from
-2021 and there are essays from before I had results worth defending, and I
+2021 and there are stories from before I had results worth defending, and I
 keep them in the same room on purpose, because they are who was writing before
 the theorems showed up.
 
@@ -31,7 +31,7 @@ think in words. I think in mathematics, in pictures, in a kind of wordless
 intuition that I then have to translate for anyone who is not inside my head,
 including, often, myself. So the way many of these pieces come into being is a
 long discourse with an AI, where I reason out loud about life or about math and
-use it to find the language my own head does not hand me. Some of the essays
+use it to find the language my own head does not hand me. Some of the writeups
 here started as exactly that conversation. The thoughts are mine, the shape of
 the argument is mine, and every mistake is mine to own; what the machine lends
 me is the wording. I would rather tell you that at the door than let you assume


### PR DESCRIPTION
Renames 'essay' to 'writeup'/'story' across all reader-facing text in the writeups section and the site-wide colophon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)