### PR TITLE
fix: restore /blog by removing conflicting CNAME

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,5 +32,10 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
           publish_branch: gh-pages
-          cname: tahabouhsine.com
+          # No cname here: the blog is a PROJECT page served at
+          # www.tahabouhsine.com/blog/ (base=/blog) as a subpath of the
+          # mlnomadpy.github.io user site, which owns the custom domain.
+          # Writing a CNAME=tahabouhsine.com into this repo's gh-pages branch
+          # conflicts with that verified domain and makes GitHub disable this
+          # repo's Pages site (the whole /blog 404 outage).
           commit_message: 'deploy: ${{ github.sha }}'

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,0 @@
-tahabouhsine.com


### PR DESCRIPTION
## Problem
`www.tahabouhsine.com/blog` was returning 404 — the entire blog was down.

## Root cause
The blog is a GitHub Pages **project site** meant to serve at `www.tahabouhsine.com/blog/` (`base: /blog`) as a subpath of the `mlnomadpy.github.io` user site, which owns the verified custom domain `tahabouhsine.com`.

This repo's deploy wrote a `CNAME=tahabouhsine.com` into its `gh-pages` branch (via `public/CNAME` + the `cname:` input in `deploy.yml`). That claims a domain already owned by the user site. GitHub resolves the conflict by **disabling this repo's Pages site** — confirmed via API (`GET repos/mlnomadpy/blog/pages` returned 404). No Pages site = nothing served the `gh-pages` branch = 404.

## Fix
- Delete `public/CNAME`
- Remove the `cname:` input from the deploy workflow

With no CNAME, the project page is automatically reachable at the user domain's `/blog` subpath.

## Recovery already applied out-of-band
- Removed `CNAME` from the live `gh-pages` branch
- Re-enabled Pages on the repo (source `gh-pages`, no custom domain) — GitHub now reports `html_url: www.tahabouhsine.com/blog/`

This PR keeps future deploys from re-introducing the conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)