### PR TITLE
Fix: companion figures 404 (missing /blog base)

### DIFF
--- a/src/content/blog/a-network-that-conserves-energy-jax-flax-nnx.mdx
+++ b/src/content/blog/a-network-that-conserves-energy-jax-flax-nnx.mdx
@@ -103,14 +103,14 @@ def rollout_energy(model, q0=1.6, p0=0.0, dt=0.05, n=600):
 In the check run the plain field drifts 6.4% of the starting energy over the rollout; the HNN holds within 0.4%. The published run's longer rollout is the figure below, drawn from the exported trajectories.
 
 <figure class="jax-fig jax-fig-wide">
-  <img src="/hamnet-pendulum-race.gif" alt="Two learned pendulum fields integrated from the same start: phase-space trajectories drawing left, true energy along each rollout drawing right; the plain field's energy leaves the dashed starting level while the HNN's stays on it" loading="lazy" />
+  <img src="/blog/hamnet-pendulum-race.gif" alt="Two learned pendulum fields integrated from the same start: phase-space trajectories drawing left, true energy along each rollout drawing right; the plain field's energy leaves the dashed starting level while the HNN's stays on it" loading="lazy" />
   <figcaption>The race, from the real run's exported rollouts. Left: phase space. Right: the true pendulum energy along each trajectory, dashes at the starting level. The plain field model reproduces the arrows and still leaks; the HNN cannot leak, because its arrows are built from a level set.</figcaption>
 </figure>
 
 What the HNN learned is worth looking at directly: one scalar over phase space whose level sets *are* the orbits.
 
 <figure class="jax-fig jax-fig-wide">
-  <img src="/hamnet-level-set.gif" alt="The learned scalar H(q,p) as a contoured landscape with the HNN trajectory tracing along a single level set" loading="lazy" />
+  <img src="/blog/hamnet-level-set.gif" alt="The learned scalar H(q,p) as a contoured landscape with the HNN trajectory tracing along a single level set" loading="lazy" />
   <figcaption>The trained HNN's scalar, contoured, with the rollout riding it. The trajectory follows one stripe because the field is the rotated gradient of this exact surface: conservation is the geometry, not a fit.</figcaption>
 </figure>
 
@@ -168,7 +168,7 @@ def step(net, opt):
 In the check run this reaches 100% on held-out moons at its training depth and 100% again at four times that depth, with the learned energy $E_\theta = \tfrac12\|p\|^2 + V_\theta(q)$ oscillating in a bounded band through the layers rather than trending anywhere. The published three-seed comparison against the parameter-matched plain net is in the explainer's table, along with the run's cleanest structural result: the energy band shrinks sixteen-fold when the step halves twice, the $h^2$ signature of a second-order symplectic integrator measured inside a trained classifier. Here is the hidden state itself, from the exported seed-0 weights.
 
 <figure class="jax-fig jax-fig-wide">
-  <img src="/hamnet-state-cloud.gif" alt="Two scatter clouds of hidden states advancing layer by layer, with a readout tracking the leapfrog net's learned energy, which stays in a narrow band, while the plain net's readout shows the quantity is undefined" loading="lazy" />
+  <img src="/blog/hamnet-state-cloud.gif" alt="Two scatter clouds of hidden states advancing layer by layer, with a readout tracking the leapfrog net's learned energy, which stays in a narrow band, while the plain net's readout shows the quantity is undefined" loading="lazy" />
   <figcaption>The hidden state through depth, layer by layer, real weights on real test points, with the readout tracking the one quantity only the leapfrog network possesses: its learned energy, holding in a band while the clouds move. The plain net's entry reads undefined, and that is the finding: not a smaller number, a missing row.</figcaption>
 </figure>
 
@@ -177,7 +177,7 @@ In the check run this reaches 100% on held-out moons at its training depth and 1
 The payoff figure re-runs both trained networks at depths they never trained at, from 4 to 128 layers, and draws each decision boundary as the sweep passes through.
 
 <figure class="jax-fig jax-fig-wide">
-  <img src="/hamnet-boundary-sweep.gif" alt="Two decision boundary maps side by side as depth sweeps from 4 to 128 layers: the leapfrog net's boundary stays put while the plain net's boundary deforms and its accuracy readout falls" loading="lazy" />
+  <img src="/blog/hamnet-boundary-sweep.gif" alt="Two decision boundary maps side by side as depth sweeps from 4 to 128 layers: the leapfrog net's boundary stays put while the plain net's boundary deforms and its accuracy readout falls" loading="lazy" />
   <figcaption>Trained at depth 16 (marked in the title as the sweep passes), run everywhere from 4 to 128. The leapfrog net's boundary sharpens into place and stays; it learned a flow, and more layers only render the same flow finer. The plain net learned a sixteen-fold composition, and at other depths it is a different function, visibly and in the accuracy readout.</figcaption>
 </figure>
 

--- a/src/content/blog/attention-is-a-compatibility-kernel-jax-flax-nnx.mdx
+++ b/src/content/blog/attention-is-a-compatibility-kernel-jax-flax-nnx.mdx
@@ -58,7 +58,7 @@ Three seeds per variant, 12,000 steps, best validation loss on held-out Shakespe
 | yat kernel | 1.5131 ± 0.0071 | 2.183 |
 
 <figure class="jax-fig jax-fig-wide">
-  <img src="/yatattn-curves.gif" alt="Validation loss curves for all six runs drawing through 12000 training steps, softmax in red and yat in blue, braiding together and settling 1.4 percent apart" loading="lazy" />
+  <img src="/blog/yatattn-curves.gif" alt="Validation loss curves for all six runs drawing through 12000 training steps, softmax in red and yat in blue, braiding together and settling 1.4 percent apart" loading="lazy" />
   <figcaption>All six runs' validation losses drawing through training, from the run's eval checkpoints. The families braid; the gap at the end is 1.4 percent. No LR sweep favors either side: both use the schedule that the softmax baseline was tuned with, which if anything spots the incumbent a head start.</figcaption>
 </figure>
 
@@ -89,24 +89,24 @@ AUROC 0.509, 0.501, 0.508 across seeds. Null, reported as such.
 The telemetry run snapshots both models' full attention tensors on one fixed validation window at four checkpoints. Two honest ways to look at them: through depth, and through training.
 
 <figure class="jax-fig jax-fig-wide">
-  <img src="/yatattn-depth-grid.png" alt="Trained attention maps for all six layers, both models side by side, causal structure changing character with depth" loading="lazy" />
+  <img src="/blog/yatattn-depth-grid.png" alt="Trained attention maps for all six layers, both models side by side, causal structure changing character with depth" loading="lazy" />
   <figcaption>The trained routing through depth, layer 1 to 6, both models on the same Shakespeare window, all heads averaged. Both develop the standard anatomy, local bands early, sparser long-range columns late; six layers are six facts, so this is a grid. The kernel model's maps are the ones computed without an exponential anywhere, and its bands are visibly fatter, the diffuseness the explainer measures as an entropy gap.</figcaption>
 </figure>
 
 Watching a single head read is where the diffuseness difference stops being a statistic. One query position advancing through the window, its full attention row at every position:
 
 <figure class="jax-fig jax-fig-wide">
-  <img src="/yatattn-reading.gif" alt="Two attention-row traces advancing across the sequence as the query position moves, the softmax row spiking hard onto single keys while the yat row spreads its mass over several" loading="lazy" />
+  <img src="/blog/yatattn-reading.gif" alt="Two attention-row traces advancing across the sequence as the query position moves, the softmax row spiking hard onto single keys while the yat row spreads its mass over several" loading="lazy" />
   <figcaption>Layer 4, one head, the attention row of each query position as the models read the window left to right, from the trained checkpoints. The softmax row (top) repeatedly spikes onto a single key; the kernel row (bottom) spreads over several. An exponential is a soft argmax; a ratio of polynomials is a genuine weighted average.</figcaption>
 </figure>
 
 <figure class="jax-fig">
-  <img src="/yatattn-checkpoints.png" alt="A grid of attention maps, four training checkpoints by two models, one layer and head, showing near-uniform haze at step 0 sharpening to structured routing at step 12000" loading="lazy" />
+  <img src="/blog/yatattn-checkpoints.png" alt="A grid of attention maps, four training checkpoints by two models, one layer and head, showing near-uniform haze at step 0 sharpening to structured routing at step 12000" loading="lazy" />
   <figcaption>One layer and head at the four telemetry checkpoints, both models: from causal haze to structure. Four snapshots are four facts, so this is a grid, not an animation.</figcaption>
 </figure>
 
 <figure class="jax-fig jax-fig-wide">
-  <img src="/yatattn-score-orbit.gif" alt="The two score landscapes over the key plane while the query orbits: the bilinear ramp rotates rigidly while the yat kernel's bright peak travels with the query" loading="lazy" />
+  <img src="/blog/yatattn-score-orbit.gif" alt="The two score landscapes over the key plane while the query orbits: the bilinear ramp rotates rigidly while the yat kernel's bright peak travels with the query" loading="lazy" />
   <figcaption>The two compatibility functions computed live from their formulas while the query orbits the plane: the bilinear ramp only rotates, scoring direction; the kernel's peak travels with the query, scoring direction and place at once. This is the geometry the explainer's draggable panel lets you feel; here it is as one continuous sweep.</figcaption>
 </figure>
 

--- a/src/content/blog/backprop-without-the-memory-jax-flax-nnx.mdx
+++ b/src/content/blog/backprop-without-the-memory-jax-flax-nnx.mdx
@@ -86,7 +86,7 @@ rev_forward.defvjp(rev_fwd, rev_bwd)
 Two details carry the memory claim. The residual tuple in `rev_fwd` holds the endpoint and the parameters, nothing indexed by depth. And the backward `lax.scan` re-derives `x_prev` before calling `f_vjp`, so the local VJP always has the input it needs without anyone having stored it. The bookkeeping through the ledger, `gv_local = gv_n + H_STEP * gx_n` and `gv_p = MU * gv_local`, is just the chain rule of the two forward lines, written by hand once.
 
 <figure class="jax-fig jax-fig-wide">
-  <img src="/revmem-ledger.gif" alt="Two lanes of layer cells animated through one training step: the standard lane banks an activation per layer and its memory meter climbs; the reversible lane carries a single moving state and its meter stays flat; meters labeled with the measured 674.0 and 3.2 MB at depth 512" loading="lazy" />
+  <img src="/blog/revmem-ledger.gif" alt="Two lanes of layer cells animated through one training step: the standard lane banks an activation per layer and its memory meter climbs; the reversible lane carries a single moving state and its meter stays flat; meters labeled with the measured 674.0 and 3.2 MB at depth 512" loading="lazy" />
   <figcaption>The two disciplines, one training step. The standard lane's bank fills during the forward sweep and drains during the backward; the reversible lane never holds more than one state. Meters carry the run's measured activation memory at depth 512.</figcaption>
 </figure>
 
@@ -109,7 +109,7 @@ The two instruments agree on the story:
 | 512 | 674.0 MB | 3.2 MB | 83.0 ms | 103.1 ms |
 
 <figure class="jax-fig">
-  <img src="/revmem-wall.png" alt="Log-log plot of activation memory against depth: the standard line climbs linearly from 13.4 to 674 MB while the reversible line is flat at 3.2 MB" loading="lazy" />
+  <img src="/blog/revmem-wall.png" alt="Log-log plot of activation memory against depth: the standard line climbs linearly from 13.4 to 674 MB while the reversible line is flat at 3.2 MB" loading="lazy" />
   <figcaption>The wall, measured by XLA's own analysis of each compiled step. Standard backprop's scratch grows linearly in depth; the reversible pass does not know how deep the network is.</figcaption>
 </figure>
 
@@ -129,21 +129,21 @@ def rewind(F, xL, vL, mu, L):
 ```
 
 <figure class="jax-fig jax-fig-wide">
-  <img src="/revmem-rewind-shear.gif" alt="Three panels, mu 0.9, 0.6, 0.3: blue forward trajectories through 64 float32 momentum layers, then orange reconstructed states rewound from the endpoint; at 0.9 the dots land on the trails, at 0.6 they deviate visibly, at 0.3 they scatter with error 1e10" loading="lazy" />
+  <img src="/blog/revmem-rewind-shear.gif" alt="Three panels, mu 0.9, 0.6, 0.3: blue forward trajectories through 64 float32 momentum layers, then orange reconstructed states rewound from the endpoint; at 0.9 the dots land on the trails, at 0.6 they deviate visibly, at 0.3 they scatter with error 1e10" loading="lazy" />
   <figcaption>The same rewind at three frictions, real float32 arithmetic. At mu = 0.9 the reconstruction lands on every footprint (error 4e-05 over 64 layers). At 0.6 it visibly shears. At 0.3 the error reaches ten billion: the algebra is exact and the arithmetic is not.</figcaption>
 </figure>
 
 And the growth is not vaguely exponential, it is the *predicted* exponential. Plotting the reconstruction error as the rewind proceeds, against the budget $\varepsilon_{32} (1/\mu)^{\ell}$ drawn dashed:
 
 <figure class="jax-fig jax-fig-wide">
-  <img src="/revmem-error-growth.gif" alt="Log-scale reconstruction error growing with each backward step for mu 0.9, 0.6, 0.3, each measured curve running parallel to its dashed predicted budget line" loading="lazy" />
+  <img src="/blog/revmem-error-growth.gif" alt="Log-scale reconstruction error growing with each backward step for mu 0.9, 0.6, 0.3, each measured curve running parallel to its dashed predicted budget line" loading="lazy" />
   <figcaption>Reconstruction error, measured at every backward step (solid) against the noise budget (dashed), one color per friction. Each curve rides its prediction's slope. The budget is not a bound, it is the mechanism.</figcaption>
 </figure>
 
 On the full network the run measures gradient agreement (cosine between the rewind gradient and the stored-activation gradient on identical weights and batch): 1.000000 everywhere the budget is small, 0.30 at $\mu = 0.6$, depth 32, where the budget crosses one, and nan at $\mu = 0.3$, depth 128, where the budget is $10^{66}$.
 
 <figure class="jax-fig">
-  <img src="/revmem-cliff.png" alt="Gradient cosine against depth for three mus with dashed verticals at each mu's predicted death depth; measured cliffs align with predictions" loading="lazy" />
+  <img src="/blog/revmem-cliff.png" alt="Gradient cosine against depth for three mus with dashed verticals at each mu's predicted death depth; measured cliffs align with predictions" loading="lazy" />
   <figcaption>Where the gradient dies, measured against the napkin prediction L* = ln(1/eps)/ln(1/mu) drawn before looking. Inside the budget the rewind gradient is exact to float precision; outside it there is nothing to rescue.</figcaption>
 </figure>
 

--- a/src/content/blog/depth-on-demand-jax-flax-nnx.mdx
+++ b/src/content/blog/depth-on-demand-jax-flax-nnx.mdx
@@ -55,14 +55,14 @@ def render_adaptive(p, x, tol, h0=T_TOTAL / L_TRAIN, h_min=T_TOTAL / 4096):
 Two bookkeeping decisions matter for honesty. `work` counts *every* leapfrog evaluation, including the probes of rejected steps, because that is what the controller actually costs; `accepted` counts only committed steps, the rendered resolution. The explainer's efficiency claims use `work`; the power law lives in `accepted`. Conflating them flatters the method by a factor of about two, so the run keeps both.
 
 <figure class="jax-fig jax-fig-wide">
-  <img src="/adepth-controller.gif" alt="A real input stepped through the trained flow by the controller: accepted states accumulate along the trajectory, a rejected probe flashes as an X, and the step-size bar below breathes, shrinking at stiff stretches and doubling on gentle ones" loading="lazy" />
+  <img src="/blog/adepth-controller.gif" alt="A real input stepped through the trained flow by the controller: accepted states accumulate along the trajectory, a rejected probe flashes as an X, and the step-size bar below breathes, shrinking at stiff stretches and doubling on gentle ones" loading="lazy" />
   <figcaption>The controller on one real spirals input, from the exported weights. Blue dots are accepted states; the X is a rejected probe forcing a halve-and-retry; the bar is the step size breathing against the dashed training step. Every decision is the run's arithmetic.</figcaption>
 </figure>
 
 The same decisions, seen as the step size breathing in time, once per tolerance:
 
 <figure class="jax-fig jax-fig-wide">
-  <img src="/adepth-h-breathing.gif" alt="Three staircase traces of step size against integration time for tolerances 0.3, 0.03, 0.003, each drawing forward in time, shrinking at the same stiff stretch of the flow and striding out on the gentle stretches" loading="lazy" />
+  <img src="/blog/adepth-h-breathing.gif" alt="Three staircase traces of step size against integration time for tolerances 0.3, 0.03, 0.003, each drawing forward in time, shrinking at the same stiff stretch of the flow and striding out on the gentle stretches" loading="lazy" />
   <figcaption>The step size along one input's render at three tolerances, drawing in integration time. All three breathe at the same places, the stiff stretches of this input's trajectory, and tightening the tolerance shrinks every step rather than adding uniform ones: 9, 15, and 36 accepted steps for the same journey. The dashed line is the uniform training step.</figcaption>
 </figure>
 
@@ -71,14 +71,14 @@ The same decisions, seen as the step size breathing in time, once per tolerance:
 Sweeping the tolerance re-renders the same inputs at five precisions. The work histogram moves; the verdicts do not:
 
 <figure class="jax-fig jax-fig-wide">
-  <img src="/adepth-tol-sweep.png" alt="Five side-by-side histograms of per-input work at tolerances 0.3 to 0.003: the distribution slides right and spreads while the accuracy in each title stays fixed" loading="lazy" />
+  <img src="/blog/adepth-tol-sweep.png" alt="Five side-by-side histograms of per-input work at tolerances 0.3 to 0.003: the distribution slides right and spreads while the accuracy in each title stays fixed" loading="lazy" />
   <figcaption>The tolerance sweep on the trained spirals net, 100 held-out inputs re-rendered at each dial setting. The bill moves; the accuracy in the titles barely does. The distribution also spreads: precision is bought input by input, not in bulk.</figcaption>
 </figure>
 
 The mean of that moving histogram is lawful. Accepted steps against tolerance on log-log axes, all three datasets, with the second-order method's slope drawn once:
 
 <figure class="jax-fig">
-  <img src="/adepth-power-law.png" alt="Log-log plot of accepted steps against tolerance for moons, rings, spirals, all three lying along a dashed slope minus one-third guide line" loading="lazy" />
+  <img src="/blog/adepth-power-law.png" alt="Log-log plot of accepted steps against tolerance for moons, rings, spirals, all three lying along a dashed slope minus one-third guide line" loading="lazy" />
   <figcaption>The measured accepted-step means across the tolerance sweep, three datasets, three seeds each. The dashed guide is the tol^(-1/3) a second-order integrator's error control predicts; the measured log-log slope is 0.32.</figcaption>
 </figure>
 
@@ -87,7 +87,7 @@ The mean of that moving histogram is lawful. Accepted steps against tolerance on
 The run's most useful negative result is the geography of effort. Rendering every point of the input plane at one tolerance and coloring by work:
 
 <figure class="jax-fig jax-fig-wide">
-  <img src="/adepth-effort-field.gif" alt="The input plane being swept row by row, each cell colored by the work the controller spent there, with the data points overlaid; the bright expensive ridges do not follow the class boundary" loading="lazy" />
+  <img src="/blog/adepth-effort-field.gif" alt="The input plane being swept row by row, each cell colored by the work the controller spent there, with the data points overlaid; the bright expensive ridges do not follow the class boundary" loading="lazy" />
   <figcaption>The effort field computed row by row by the real renderer at tol 0.03, data points overlaid. The expensive ridges follow the stiff regions of the learned potential, not the decision boundary; the correlation between work and classification margin stays near zero on all seeds.</figcaption>
 </figure>
 


### PR DESCRIPTION
The four new JAX companions referenced figures as `/hamnet-*.gif` etc.; the site deploys under base `/blog` and Astro does not rewrite raw `<img>` srcs in MDX, so all figures 404ed. Prefixed all 19 paths (matching the older companions' `/blog/momentum-orbits.gif` pattern); each verified 200 from the built site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)