### PR TITLE
Writeups: Changing Wells

### DIFF
--- a/src/content/writeups/changing-wells.mdx
+++ b/src/content/writeups/changing-wells.mdx
@@ -1,0 +1,365 @@
+---
+title: "Changing Wells"
+description: "A frog cannot measure the well while it is still in the well, and you cannot tell you are being boiled until you climb out. On the peace I found in quiet rooms, how drama and politics eat the only two things I actually own, how taking a break became my instrument for detecting toxicity, and what happens to an ego when you move it to a bigger sky."
+seoDescription: "You cannot see the well from inside it, and you cannot feel the boiling until you climb out. On quiet, drama, toxic environments, and rebuilding an ego that survives relocation."
+pubDate: 2026-07-27
+tags: [notes, ego, environment, growth, boundaries, personal]
+draft: false
+---
+
+The first real peace I remember was not a beach, or a holiday, or anything that
+would photograph well. It was an ordinary quiet room, late, everyone gone, no
+notifications, no meeting to prepare for, nobody to manage. Just me and my
+thoughts, and the small surprise of discovering that my thoughts were decent
+company once nothing else was shouting.
+
+That surprise is the whole essay, really. Because it meant something had been
+shouting. For months I had assumed the noise in my head was me. It was not. It
+was the room I had been standing in, and when I finally stepped out of the room,
+the noise did not follow, which is how I learned it had never been mine.
+
+## The quiet is not empty, it is where you finally hear yourself
+
+I used to think of silence as an absence, a gap between the parts of life where
+things happen. Now I think it is the only place where a certain kind of thinking
+is possible at all.
+
+There is a mode you drop into, alone, with no audience and no clock, where the
+mind stops performing. It is not meditation, exactly, or at least I did not
+arrive at it through any technique. It is closer to what happens when you remove
+every source of reaction from your environment and your brain, having nothing
+left to react to, quietly turns around and starts working on the things that
+actually matter to you. The real question surfaces. The idea you had been
+circling without noticing arrives whole. You find you have an opinion about your
+own life that you had never had time to form.
+
+That state is fragile in a specific way. It cannot survive an audience. The
+moment there is someone to impress or someone to defend against, the machinery
+turns outward and the deep thing goes back under. Which means the quiet is not a
+luxury I earn after the work. It is the condition the work requires, and every
+environment I have ever been in has treated it as the first thing to spend.
+
+## Drama is a tax, and it collects in the only currency I own
+
+I own exactly two things. Time, which is fixed and leaving, and energy, which is
+smaller than I want it to be and does not carry over to tomorrow. Everything I
+will ever make has to be bought with those two. That is the entire budget.
+
+Drama is expensive in a way that is easy to underestimate because it does not
+bill you at the counter. A twenty minute conflict costs twenty minutes plus the
+hour afterward that you spend replaying it, plus the evening it colors, plus the
+next morning where you are drafting the reply you will never send while your
+actual work sits open in another window. Politics is worse because it is
+continuous. It is not an event, it is a background process, and it never
+terminates. Who is aligned with whom this month. What that sentence in the
+meeting actually meant. Whether being left off that email was a signal or an
+accident, and what the correct response is to a signal you cannot confirm.
+
+None of that is thinking. It occupies the exact same hardware as thinking, it
+feels like thinking while you are doing it, and it produces nothing. And it is
+greedy. It takes the best hours, the fresh ones, the ones where the hard problem
+would have been solvable, and it leaves you the tired hours to do real work in.
+I have had entire months where I was busy every day, exhausted every night, and
+could not name one thing I had learned. The energy went somewhere. It went into
+maintaining a position in a status game I never consciously agreed to enter.
+
+The cruelest part is that drama recruits you by making itself feel urgent and
+important. It always seems like this particular conflict is the exception, the
+one that genuinely matters, the one where not responding would be a real loss.
+It never is. Two wells later you will not be able to remember the names of the
+people involved.
+
+## A frog cannot measure the well while it is still in the well
+
+Here is the problem with a bad environment: it does not present itself as an
+environment. It presents itself as reality.
+
+The frog at the bottom of the well is not stupid, and it is not in denial. It
+has simply never had access to a second data point. It sees a circle of sky and
+correctly concludes that the sky is a circle, because from where it sits, that
+is the sky, and every other frog it has ever met agrees. The well's walls are not
+experienced as walls. They are experienced as the shape of the world.
+
+And the boiling is the same failure of instrumentation, running on a slower
+clock. Nobody notices a temperature change of one degree. What you notice is a
+difference, and if the environment degrades slowly enough, there is never a
+difference to notice, only a new normal that arrives one degree at a time. You do
+not think "this place is draining me." You think you have gotten tired lately.
+You think you are less curious than you used to be, and that this is probably a
+normal part of getting older, and that you should try to be more disciplined. You
+diagnose yourself, always, because you are the only variable you can see. The
+water is not a variable. The water is just what being alive feels like.
+
+You cannot detect the boiling from inside the pot. It is not a matter of being
+smart or honest enough. The information is genuinely unavailable at that
+position, because measuring a temperature requires a second temperature, and
+measuring a well requires having stood somewhere that is not the well.
+
+## So the break became my instrument
+
+This is the practical thing I have learned, and it is the reason I now defend my
+breaks like equipment rather than treating them like rewards.
+
+When I suspect something is wrong and cannot tell whether the problem is the
+place or me, I leave. Not permanently, not dramatically. I take a real break, and
+by real I mean I actually disconnect from the entire apparatus: the channels, the
+group, the people, the ambient obligation to have an opinion about what happened
+on Tuesday. A weekend is usually not enough. A weekend just gets you through the
+withdrawal. It takes long enough that the background process finally terminates,
+and you stop composing replies in your head, and one morning you wake up and the
+first thought is not about them.
+
+And then the instrument gives its reading, and the reading is unmistakable.
+
+The first signal is what fills the vacuum. If the drama drains out and what rises
+in its place is curiosity, real curiosity, the itch about a problem I had
+forgotten I cared about, then the fire was never gone. It was just being
+outcompeted for the same fuel. That tells me the problem was never my discipline
+or my age or my character. It was allocation, and something else was doing the
+allocating.
+
+The second signal is the re-entry. Going back is the actual measurement, because
+you return with a recalibrated baseline, and for about a day, before you
+re-acclimate, you can feel the temperature. You walk into the room and your body
+tightens before anyone has said anything. You read the first message of the
+morning and feel the specific fatigue arrive on schedule. You notice you have
+started performing again within ten minutes. That flinch is data. It is the
+cleanest data you will ever get about a place, and it is only available in that
+narrow window, which is why I pay attention to the first day back and distrust
+everything I feel by the second week.
+
+The third signal is the one that ends things. Sometimes you climb out, look
+around, and realize the well is not poisoned at all. It is just small. Nothing is
+wrong with it. It simply cannot hold what you have become, and no amount of
+effort inside it will change its dimensions. You cannot learn this from inside
+either. From inside, a ceiling and a sky are the same thing.
+
+## Every well has a sky, and it is not the sky
+
+The first time I climbed out and stood somewhere genuinely larger, the thing that
+hit me was not ambition. It was embarrassment, and it was retroactive.
+
+Because from up here, I could see the well, and it was small. Not small as an
+insult, just small as a measurement. And the drama that had eaten years of my
+attention, the alliances, the slights, the question of who was ahead of whom,
+turned out to be a weather system inside a container about the width of a room.
+People had been fighting for a bigger share of something that, viewed from
+outside, was not big. Including me. Especially me.
+
+That is the vertigo of changing wells. Not the new place. The sudden accurate
+scale of the old one, and the arithmetic that follows about how much of your one
+supply of time you spent on things whose entire importance was local.
+
+And then, once the embarrassment passes, the second thing arrives, which is
+better: if that was a well, this is also a well. This place with its bigger sky
+is somebody's small circle, and above it is another one, and the ceiling I am
+looking at right now is not the sky either. That thought is either terrifying or
+freeing depending on the day, and mostly I have found it freeing, because it
+means the climb is the permanent condition and not a problem to be solved once.
+
+## Changing wells changes the physics your ego runs on
+
+Here is the part nobody warns you about. Your ego does not travel well, because
+your ego is not a property of you. It is a relationship between you and a
+specific environment, and when you move, the relationship does not come with you.
+
+Every well runs on its own physics. There is a local currency, whatever that
+place actually rewards, and it is rarely what it says it rewards. There is a
+local scoreboard that everyone can read and nobody has written down. There is a
+local definition of impressive. And your ego is not a solid object you carry; it
+is a reading on that local instrument, calibrated by years of small feedback,
+and the reading is only meaningful in the room where the instrument lives.
+
+So you move, and the instrument is gone. The thing that made you notable does not
+register here, not because these people are dismissive but because here it is
+simply the baseline, the entry condition, the thing everyone already has. Your
+whole accumulated standing converts at an exchange rate you did not expect, and
+the conversion happens in public, and it is humiliating in a way that is very
+hard to describe to people who have never moved.
+
+I do not think that humiliation is a bug. I think it is the tuition. The ego I
+brought into the bigger room was not strong. It was just well-adapted, the way
+an animal is well-adapted to one valley and helpless one ridge over. It had been
+built out of comparisons against a fixed, small set of people, which means it was
+never really a measurement of me. It was a measurement of who happened to be
+standing nearby.
+
+## Meeting people from everywhere, and the shallowness that revealed
+
+Nothing rearranged me faster than sitting in rooms with people from everywhere.
+
+You meet someone who casually knows a field you have been circling for a year.
+Someone who built the thing you were still describing as an idea, and built it
+two years ago, and has already found the flaw in it that you have not reached
+yet. Someone whose default, unremarkable, Tuesday-afternoon standard of rigor is
+higher than the standard you were quietly proud of. And none of them are
+performing. That is what does it. They are not showing off, they are just
+operating, and their operating level is the thing you had been treating as your
+ceiling.
+
+The first reaction is a flinch, and I want to be honest that the flinch is ugly.
+There is a moment where the ego, sensing the threat, goes looking for a reason to
+discount them. It finds one. It always finds one. That reflex is the shallow ego
+protecting itself, and learning to notice it in the half second before it takes
+over is maybe the most useful skill I have picked up.
+
+Because on the other side of the flinch is the actual gift, which is scale. You
+walk out of those rooms having lost an illusion and gained a map. You know how
+far it is now. You know what the real distance between here and good is, and it
+is much larger than the well told you, and, crucially, it is finite. It is a
+distance. Distances can be crossed. The people who intimidated you are not a
+different species; they are further along a road you are on, and every one of
+them was, at some point, standing where you are with the same flinch.
+
+If you want to touch the sky, that is the number you need. Not encouragement. The
+honest distance. And the only way to get it is to stand next to people who make
+you feel small, repeatedly, on purpose, until the feeling stops being an injury
+and starts being a measurement.
+
+## Rebuilding the ego on something that survives relocation
+
+So the old ego is gone, or should be. The question is what you build in its
+place, because you do need something. A person with no floor cannot take a risk,
+and research is nothing but risk.
+
+What I have arrived at is that the new one has to be built out of things that
+convert across wells, and there are not many. Rank does not convert. Reputation
+does not convert. Being the person who knows everyone does not convert. What
+converts is: can I learn something hard, on my own, without permission. Do I
+finish. Am I honest about being wrong, quickly, before it costs someone else. Is
+the thing I made actually true.
+
+Those are portable because they are not comparisons. They do not require a
+scoreboard or a set of nearby people to be measured against. They are properties
+of the work and of the animal doing it, and they read the same in any room on
+earth. An ego built on those is quieter than the old one. It does not feel like
+confidence, exactly. It feels more like a floor: not the belief that I am ahead
+of anyone, just the settled knowledge that I can find things out and I will not
+lie about what I find. That floor is enough to stand on in a room full of people
+better than me, which is the only room worth being in.
+
+And that quieter ego has a property the old one lacked: it does not need drama.
+It has no position to defend, because its standing does not come from the local
+scoreboard, so an insult in the hallway is not an attack on the foundation. Most
+of the conflict I used to be pulled into, I was pulled into because a fragile
+local ego experienced every small status event as existential. Remove the fragile
+local ego and most of the drama simply stops being interesting, which is the same
+as being free of it.
+
+## Toxicity does not just hurt, it caps you
+
+I want to be precise about the damage, because "toxic environment" has been said
+so often it has stopped meaning anything.
+
+A toxic environment is not one where hard things happen. Hard is fine. Hard is
+what I came for. A toxic environment is one where the cost of existing in it is
+paid out of the same account that growth is paid from. That is the whole
+definition. The pettiness, the ego management, the politics, the emotional
+overhead of a person who must be handled: none of it is neutral, because all of
+it draws on the same finite supply of attention and nerve that the actual work
+needs. Toxicity does not sit beside your growth. It eats it.
+
+And it does not announce the theft. What you notice, if you notice anything, is
+that you are less curious than you were. That you have stopped starting things.
+That your appetite for the hard, uncertain, long project has quietly declined and
+been replaced by a preference for small safe tasks that cannot go wrong. You will
+call that maturity. It is not maturity. It is an animal that has learned the
+environment punishes exposure, and has adapted by making itself smaller, and the
+adaptation is invisible from inside because it happened one degree at a time.
+
+That is why I treat toxicity as a growth question rather than a comfort question.
+I am not asking whether a place is pleasant. I am asking what it does to my
+ceiling. A place that costs me a little happiness and buys me a lot of growth is
+a trade I will take every time. A place that is pleasant and caps me is more
+dangerous than one that is openly hostile, because there is no alarm attached.
+
+## Facing it, and where the line goes
+
+Leaving is not the first move. It is the last one, and if it is your only move
+you will spend your life moving.
+
+The first move is to say the thing out loud, in the room, plainly, once. Most
+environments have never actually been told. Not in the sense of a hint or a
+carefully worded email, but told: this is what is happening, this is what it
+costs, this is what I need instead. Sometimes that works and the place adjusts,
+and when it does you have gained something more valuable than comfort, which is
+evidence that the place is capable of adjusting.
+
+But you have to say it as a boundary and not as a complaint, and I only recently
+learned the difference. A complaint is about them and asks them to change. A
+boundary is about me and describes what I will do. I do not take the meeting that
+exists to relitigate the last meeting. I do not participate in the conversation
+about who is aligned with whom. I do not respond to the message designed to make
+me anxious on a schedule that rewards making me anxious. I do not carry the
+emotional weather of someone who is not managing their own. A boundary needs no
+agreement. It needs enforcement, and the enforcement is entirely mine, and it
+costs something the first three times and almost nothing after that.
+
+What you learn by drawing one is the actual answer to the question you were
+asking. Because you find out how the place responds to a person with edges. A
+healthy place absorbs it, adjusts slightly, and moves on. A toxic place treats
+the boundary itself as the offense, and escalates, and the escalation is the
+diagnosis. You wanted to know whether it was you or the room. Draw one line and
+the room will tell you.
+
+And then, if the answer is the room, and the room will not change, leaving stops
+being an emotional decision and becomes an arithmetic one. Time is fixed. Energy
+does not carry over. This is what it costs to stay. That is all.
+
+## The new well has its own toxicity, and they will call it the norm
+
+Here is the trap I nearly fell into, and the reason I am writing this down.
+
+You climb out. The new place is bigger, better, genuinely a step up, and you are
+grateful, and gratitude makes you compliant. And then you notice it. A different
+flavor of the same thing. A person everyone tolerates. A ritual that wastes
+everyone's week. A cruelty that is treated as rigor. And when you flinch, someone
+explains, kindly, that this is how it works here. That everyone goes through it.
+That it is part of the culture, and you will get used to it.
+
+They are not lying. You will get used to it. That is exactly the danger.
+
+Because "this is the norm here" is not an argument, it is a description, and the
+whole reason it lands is that you just arrived and you have not earned the
+standing to disagree. The people telling you have adapted to this well, and their
+adaptation is real and hard-won and they are not wrong about the local physics.
+But they are calibrated to this well, and I am not staying in this well. I am
+aiming at one I have not reached yet, and the standard that matters to me is not
+the standard here, it is the standard there. Every norm I accept because it is
+normal here is a habit I will have to break to get there.
+
+So the answer is no. Politely, without a speech, without trying to reform anyone,
+but no. I will take the growth this place offers and decline the toxicity it
+bundles with it, and I will not pretend the bundle is indivisible just because
+everyone here has stopped trying to separate it. The two are not the same
+purchase, and being new is not a reason to accept the whole package. It is
+actually the best moment to refuse, because right now, before I acclimate, I can
+still feel the temperature.
+
+Every well will offer you this deal. Take the good, absorb the poison, call it
+culture. The deal is always available and it always looks reasonable and the cost
+is always the same: a little of the fire, a little of the ceiling, one degree at
+a time.
+
+## What the climb actually is
+
+I do not have a destination anymore, and I have stopped wanting one. What I have
+is a practice, and it is roughly this.
+
+Protect the quiet, because it is where the real thinking happens and it is the
+first thing every environment tries to spend. Refuse the drama, not from
+superiority but from arithmetic, because it bills in the only currency I have.
+Leave, on purpose, at intervals, so that I keep a second thermometer and never
+have to take a room's word for what temperature is normal. When I climb, expect
+the ego to shatter, and let it, and rebuild it out of the few things that survive
+the move. Stand next to people who make me feel small until the feeling turns
+into a distance I can measure. Say the thing once, plainly. Draw the line and
+watch what the room does with it. And never accept a new well's poison as the
+price of its sky, because there is another sky above this one and I am not
+finished.
+
+The frog that climbs out does not discover that the sky is bigger. It discovers
+that it never once saw the sky, only a circle, and that everything it believed
+about the size of things was a fact about the well and not about the world.
+
+That is worth every ego I have had to lose, and I expect to lose several more.


### PR DESCRIPTION
Personal writeup for the `/writeups` collection. Companion in spirit to *Wasted Potential*.

A frog cannot measure the well while it is still in the well, and you cannot tell you are being boiled until you climb out. Covers the peace found in quiet rooms, drama and politics as a tax on time and energy, taking a break as the instrument for detecting toxicity, what changing wells does to the physics an ego runs on, meeting people from everywhere, rebuilding on the few things that survive relocation, drawing boundaries, and refusing a new well's toxicity just because it is the local norm.

- `src/content/writeups/changing-wells.mdx` (`draft: false`)

Production build verified locally; page renders at `/blog/writeups/changing-wells/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)